### PR TITLE
feat: add log download button to log viewer

### DIFF
--- a/src/lib/components/kind-viewer/kind-viewer-actions/default/log-viewer.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/default/log-viewer.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { createClient, type Transport } from '@connectrpc/connect';
 	import ArrowDownIcon from '@lucide/svelte/icons/arrow-down';
+	import DownloadIcon from '@lucide/svelte/icons/download';
+	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
 	import PauseIcon from '@lucide/svelte/icons/pause';
 	import PlayIcon from '@lucide/svelte/icons/play';
 	import { RuntimeService } from '@otterscale/api/runtime/v1';
@@ -41,6 +43,7 @@
 	let logContainer = $state<HTMLElement | undefined>(undefined);
 	let showScrollButton = $state(false);
 	let showAllData = $state(false);
+	let downloading = $state(false);
 
 	$effect(() => {
 		if (active) {
@@ -131,6 +134,47 @@
 			abortController = null;
 		}
 	}
+
+	async function downloadLogs() {
+		if (!podName || downloading) return;
+		downloading = true;
+
+		try {
+			const allLines: string[] = [];
+			const dlAbort = new AbortController();
+			const stream = client.podLog(
+				{
+					cluster,
+					namespace,
+					name: podName,
+					container: effectiveContainer,
+					follow: false,
+					previous
+				},
+				{ signal: dlAbort.signal }
+			);
+
+			for await (const response of stream) {
+				if (response.data && response.data.length > 0) {
+					const text = new TextDecoder().decode(response.data);
+					const lines = text.split('\n').filter((l) => l.length > 0);
+					allLines.push(...lines);
+				}
+			}
+
+			const blob = new Blob([allLines.join('\n')], { type: 'text/plain' });
+			const url = URL.createObjectURL(blob);
+			const a = document.createElement('a');
+			a.href = url;
+			a.download = `${podName}_${effectiveContainer}_${new Date().toISOString().replace(/[:.]/g, '-')}.log`;
+			a.click();
+			URL.revokeObjectURL(url);
+		} catch (error) {
+			logLines = [...logLines, `[Error] Failed to download logs: ${error}`];
+		} finally {
+			downloading = false;
+		}
+	}
 </script>
 
 <!-- Controls -->
@@ -195,7 +239,15 @@
 	>
 		<span class="text-xs">All</span>
 	</Toggle>
-	<div class="ml-auto">
+	<div class="ml-auto flex items-center gap-2">
+		<Button size="sm" variant="outline" onclick={downloadLogs} disabled={downloading || !podName}>
+			{#if downloading}
+				<LoaderCircleIcon size={14} class="animate-spin" />
+			{:else}
+				<DownloadIcon size={14} />
+			{/if}
+			{downloading ? 'Downloading...' : 'Download'}
+		</Button>
 		<Button
 			size="sm"
 			variant="outline"

--- a/src/lib/components/kind-viewer/kind-viewer-actions/default/log-viewer.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/default/log-viewer.svelte
@@ -140,7 +140,7 @@
 		downloading = true;
 
 		try {
-			const allLines: string[] = [];
+			const chunks: BlobPart[] = [];
 			const dlAbort = new AbortController();
 			const stream = client.podLog(
 				{
@@ -156,13 +156,11 @@
 
 			for await (const response of stream) {
 				if (response.data && response.data.length > 0) {
-					const text = new TextDecoder().decode(response.data);
-					const lines = text.split('\n').filter((l) => l.length > 0);
-					allLines.push(...lines);
+					chunks.push(new Uint8Array(response.data));
 				}
 			}
 
-			const blob = new Blob([allLines.join('\n')], { type: 'text/plain' });
+			const blob = new Blob(chunks, { type: 'text/plain' });
 			const url = URL.createObjectURL(blob);
 			const a = document.createElement('a');
 			a.href = url;


### PR DESCRIPTION
Add a Download button in the log viewer controls that fetches all historical logs from the pod (without tail limit) and saves them as a .log file locally, using the pod name, container, and timestamp as the filename.