### PR TITLE
Replace js-yaml load with yaml parse

### DIFF
--- a/src/lib/components/artifact-viewer/artifact-viewer-actions/install-from-harbor.svelte
+++ b/src/lib/components/artifact-viewer/artifact-viewer-actions/install-from-harbor.svelte
@@ -8,13 +8,12 @@
 	import { type Schema, SubmitButton, type UiSchemaRoot } from '@sjsf/form';
 	import type { Row } from '@tanstack/table-core';
 	import Ajv from 'ajv';
-	import { load } from 'js-yaml';
 	import lodash from 'lodash';
 	import { mode as themeMode } from 'mode-watcher';
 	import { getContext, onMount } from 'svelte';
 	import Monaco from 'svelte-monaco';
 	import { toast } from 'svelte-sonner';
-	import { stringify } from 'yaml';
+	import { parse, stringify } from 'yaml';
 
 	import Form from '$lib/components/dynamic-form/form.svelte';
 	import EditorWidget from '$lib/components/dynamic-form/widgets/editor.svelte';
@@ -87,7 +86,7 @@
 			values: {}
 		}
 	});
-	let value = $derived(stringify(values));
+	let value = $derived(stringify(values, { schema: 'yaml-1.1' }));
 
 	const helmRepository = row.original.helmRepository as SourceToolkitFluxcdIoV1HelmRepository;
 
@@ -394,7 +393,7 @@
 							posthook: () => {
 								handleNext();
 								try {
-									const structuredValues = load(lodash.get(values, 'spec.values') as string);
+									const structuredValues = parse(lodash.get(values, 'spec.values') as string);
 
 									lodash.set(values, 'spec.values', structuredValues);
 								} catch (error) {
@@ -455,7 +454,7 @@
 							if (isSubmitting) return;
 							isSubmitting = true;
 
-							const isValid = validate(load(value));
+							const isValid = validate(parse(value));
 
 							if (!isValid) {
 								console.error(`Validation errors: ${JSON.stringify(validate.errors)}`);
@@ -464,7 +463,7 @@
 								return;
 							}
 
-							const name = lodash.get(load(value), 'metadata.name');
+							const name = lodash.get(parse(value), 'metadata.name');
 
 							toast.promise(
 								async () => {

--- a/src/lib/components/artifact-viewer/artifact-viewer-actions/install-from-harbor.svelte
+++ b/src/lib/components/artifact-viewer/artifact-viewer-actions/install-from-harbor.svelte
@@ -392,10 +392,10 @@
 						handleSubmit={{
 							posthook: () => {
 								handleNext();
+								const raw = lodash.get(values, 'spec.values');
+								if (typeof raw !== 'string') return;
 								try {
-									const structuredValues = parse(lodash.get(values, 'spec.values') as string);
-
-									lodash.set(values, 'spec.values', structuredValues);
+									lodash.set(values, 'spec.values', parse(raw) ?? {});
 								} catch (error) {
 									console.error('Failed to load values:', error);
 									toast.error('Failed to load values');
@@ -454,7 +454,17 @@
 							if (isSubmitting) return;
 							isSubmitting = true;
 
-							const isValid = validate(parse(value));
+							let parsed: unknown;
+							try {
+								parsed = parse(value);
+							} catch (error) {
+								console.error('Failed to parse YAML:', error);
+								toast.error('Invalid YAML. Please check the syntax.');
+								isSubmitting = false;
+								return;
+							}
+
+							const isValid = validate(parsed);
 
 							if (!isValid) {
 								console.error(`Validation errors: ${JSON.stringify(validate.errors)}`);
@@ -463,7 +473,7 @@
 								return;
 							}
 
-							const name = lodash.get(parse(value), 'metadata.name');
+							const name = lodash.get(parsed, 'metadata.name');
 
 							toast.promise(
 								async () => {

--- a/src/lib/components/module-viewer/module-viewer-actions/install.svelte
+++ b/src/lib/components/module-viewer/module-viewer-actions/install.svelte
@@ -6,11 +6,10 @@
 	import { RuntimeService } from '@otterscale/api/runtime/v1';
 	import type { SourceToolkitFluxcdIoV1HelmRepository } from '@otterscale/types';
 	import type { Row } from '@tanstack/table-core';
-	import { load } from 'js-yaml';
 	import lodash from 'lodash';
 	import { getContext } from 'svelte';
 	import { toast } from 'svelte-sonner';
-	import { stringify } from 'yaml';
+	import { parse, stringify } from 'yaml';
 
 	import {
 		encodeHarborURIComponent,
@@ -141,7 +140,7 @@
 								}
 							}
 						},
-						values: load(helmValues) ?? {}
+						values: parse(helmValues) ?? {}
 					}
 				};
 
@@ -151,7 +150,7 @@
 					group,
 					version,
 					resource,
-					manifest: new TextEncoder().encode(stringify(manifest))
+					manifest: new TextEncoder().encode(stringify(manifest, { schema: 'yaml-1.1' }))
 				});
 			},
 			{

--- a/src/lib/components/module-viewer/module-viewer-actions/setup/default.svelte
+++ b/src/lib/components/module-viewer/module-viewer-actions/setup/default.svelte
@@ -421,10 +421,10 @@
 						handleSubmit={{
 							posthook: () => {
 								handleNext();
+								const raw = lodash.get(values, 'spec.values');
+								if (typeof raw !== 'string') return;
 								try {
-									const structuredValues = parse(lodash.get(values, 'spec.values') as string);
-
-									lodash.set(values, 'spec.values', structuredValues);
+									lodash.set(values, 'spec.values', parse(raw) ?? {});
 								} catch (error) {
 									console.error('Failed to load values:', error);
 									toast.error('Failed to load values');
@@ -483,7 +483,17 @@
 							if (isSubmitting) return;
 							isSubmitting = true;
 
-							const isValid = validate(parse(value));
+							let parsed: unknown;
+							try {
+								parsed = parse(value);
+							} catch (error) {
+								console.error('Failed to parse YAML:', error);
+								toast.error('Invalid YAML. Please check the syntax.');
+								isSubmitting = false;
+								return;
+							}
+
+							const isValid = validate(parsed);
 
 							if (!isValid) {
 								console.error(`Validation errors: ${JSON.stringify(validate.errors)}`);
@@ -492,7 +502,7 @@
 								return;
 							}
 
-							const name = lodash.get(parse(value), 'metadata.name');
+							const name = lodash.get(parsed, 'metadata.name');
 
 							toast.promise(
 								async () => {

--- a/src/lib/components/module-viewer/module-viewer-actions/setup/default.svelte
+++ b/src/lib/components/module-viewer/module-viewer-actions/setup/default.svelte
@@ -8,13 +8,12 @@
 	import { type Schema, SubmitButton, type UiSchemaRoot } from '@sjsf/form';
 	import type { Row } from '@tanstack/table-core';
 	import Ajv from 'ajv';
-	import { load } from 'js-yaml';
 	import lodash from 'lodash';
 	import { mode as themeMode } from 'mode-watcher';
 	import { getContext, onMount } from 'svelte';
 	import Monaco from 'svelte-monaco';
 	import { toast } from 'svelte-sonner';
-	import { stringify } from 'yaml';
+	import { parse, stringify } from 'yaml';
 
 	import {
 		encodeHarborURIComponent,
@@ -98,7 +97,7 @@
 			values: {}
 		}
 	});
-	let value = $derived(stringify(values));
+	let value = $derived(stringify(values, { schema: 'yaml-1.1' })); // k8s use yaml 1.1
 
 	async function fetchModuleVersions(project: string, chartName: string): Promise<ModuleType[]> {
 		let moduleVersions: ModuleType[] = [];
@@ -423,7 +422,7 @@
 							posthook: () => {
 								handleNext();
 								try {
-									const structuredValues = load(lodash.get(values, 'spec.values') as string);
+									const structuredValues = parse(lodash.get(values, 'spec.values') as string);
 
 									lodash.set(values, 'spec.values', structuredValues);
 								} catch (error) {
@@ -484,7 +483,7 @@
 							if (isSubmitting) return;
 							isSubmitting = true;
 
-							const isValid = validate(load(value));
+							const isValid = validate(parse(value));
 
 							if (!isValid) {
 								console.error(`Validation errors: ${JSON.stringify(validate.errors)}`);
@@ -493,7 +492,7 @@
 								return;
 							}
 
-							const name = lodash.get(load(value), 'metadata.name');
+							const name = lodash.get(parse(value), 'metadata.name');
 
 							toast.promise(
 								async () => {


### PR DESCRIPTION
Updated the code to use the 'parse' method from the 'yaml' package instead of 'load' from 'js-yaml' for better compatibility with YAML 1.1 specifications.