### PR TITLE
fix(configmap): prevent confirm button from becoming unresponsive aft…

### DIFF
--- a/src/lib/components/kind-viewer/kind-viewer-actions/default/edit.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/default/edit.svelte
@@ -218,12 +218,14 @@
 		isSubmitting = true;
 
 		// Check for validation errors before submission
-		if (monacoInstance && editorInstance) {
-			const model = editorInstance.getModel();
+		const monaco = monacoInstance;
+		const editor = editorInstance;
+		if (monaco && editor) {
+			const model = editor.getModel();
 			if (model) {
-				const markers = monacoInstance.editor.getModelMarkers({ resource: model.uri });
+				const markers = monaco.editor.getModelMarkers({ resource: model.uri });
 				const hasErrors = markers.some(
-					(marker) => marker.severity === monacoInstance!.MarkerSeverity.Error
+					(marker) => marker.severity === monaco.MarkerSeverity.Error
 				);
 				if (hasErrors) {
 					toast.error('Please fix all YAML errors before submitting', {
@@ -242,6 +244,9 @@
 		try {
 			initialStructuredValue = load(stringify(object), { schema: JSON_SCHEMA });
 			currentStructuredValue = load(value, { schema: JSON_SCHEMA });
+			if (!currentStructuredValue || typeof currentStructuredValue !== 'object') {
+				throw new Error('Parsed YAML is not a valid object');
+			}
 		} catch (error) {
 			toast.error(`Invalid YAML: ${(error as Error).message}`, {
 				duration: 5000,

--- a/src/lib/components/kind-viewer/kind-viewer-actions/default/edit.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/default/edit.svelte
@@ -217,8 +217,39 @@
 
 		isSubmitting = true;
 
-		const initialStructuredValue: any = load(stringify(object), { schema: JSON_SCHEMA });
-		const currentStructuredValue: any = load(value, { schema: JSON_SCHEMA });
+		// Check for validation errors before submission
+		if (monacoInstance && editorInstance) {
+			const model = editorInstance.getModel();
+			if (model) {
+				const markers = monacoInstance.editor.getModelMarkers({ resource: model.uri });
+				const hasErrors = markers.some(
+					(marker) => marker.severity === monacoInstance!.MarkerSeverity.Error
+				);
+				if (hasErrors) {
+					toast.error('Please fix all YAML errors before submitting', {
+						duration: 5000,
+						closeButton: true
+					});
+					isSubmitting = false;
+					return;
+				}
+			}
+		}
+
+		let initialStructuredValue: any;
+		let currentStructuredValue: any;
+
+		try {
+			initialStructuredValue = load(stringify(object), { schema: JSON_SCHEMA });
+			currentStructuredValue = load(value, { schema: JSON_SCHEMA });
+		} catch (error) {
+			toast.error(`Invalid YAML: ${(error as Error).message}`, {
+				duration: 5000,
+				closeButton: true
+			});
+			isSubmitting = false;
+			return;
+		}
 
 		const patches = jsonpatch.compare(initialStructuredValue, currentStructuredValue);
 

--- a/src/lib/components/kind-viewer/kind-viewer-actions/default/edit.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/default/edit.svelte
@@ -40,7 +40,7 @@
 		onOpenChangeComplete: () => void;
 	} = $props();
 
-	let value = $derived(stringify(object));
+	let value = $state(stringify(object));
 
 	let editorInstance: import('monaco-editor').editor.IStandaloneCodeEditor | undefined =
 		$state(undefined);
@@ -215,46 +215,22 @@
 	function handleConfirm() {
 		if (isSubmitting) return;
 
-		isSubmitting = true;
-
-		// Check for validation errors before submission
-		const monaco = monacoInstance;
-		const editor = editorInstance;
-		if (monaco && editor) {
-			const model = editor.getModel();
-			if (model) {
-				const markers = monaco.editor.getModelMarkers({ resource: model.uri });
-				const hasErrors = markers.some(
-					(marker) => marker.severity === monaco.MarkerSeverity.Error
-				);
-				if (hasErrors) {
-					toast.error('Please fix all YAML errors before submitting', {
-						duration: 5000,
-						closeButton: true
-					});
-					isSubmitting = false;
-					return;
-				}
-			}
-		}
-
-		let initialStructuredValue: any;
-		let currentStructuredValue: any;
-
-		try {
-			initialStructuredValue = load(stringify(object), { schema: JSON_SCHEMA });
-			currentStructuredValue = load(value, { schema: JSON_SCHEMA });
-			if (!currentStructuredValue || typeof currentStructuredValue !== 'object') {
-				throw new Error('Parsed YAML is not a valid object');
-			}
-		} catch (error) {
-			toast.error(`Invalid YAML: ${(error as Error).message}`, {
-				duration: 5000,
-				closeButton: true
-			});
-			isSubmitting = false;
+		const document = parseDocument(value);
+		if (document.errors.length > 0) {
+			toast.error('YAML syntax errors found. Please fix them before submitting.');
 			return;
 		}
+
+		const parsed = document.toJS() as Record<string, any>;
+		if (!validate(parsed)) {
+			toast.error(`Validation errors: ${JSON.stringify(validate.errors)}`);
+			return;
+		}
+
+		isSubmitting = true;
+
+		const initialStructuredValue: any = load(stringify(object), { schema: JSON_SCHEMA });
+		const currentStructuredValue: any = load(value, { schema: JSON_SCHEMA });
 
 		const patches = jsonpatch.compare(initialStructuredValue, currentStructuredValue);
 


### PR DESCRIPTION
…er YAML errors

- Add error validation check before submission
- Wrap YAML parsing in try-catch block
- Reset isSubmitting flag on validation/parsing errors
- Display clear error messages to users

Fixes issue where confirm button would stop working after fixing YAML validation errors in ConfigMap edit dialog.