### PR TITLE
fix: resolve any-type lint warnings in kind-viewer action components

### DIFF
--- a/src/lib/components/kind-viewer/kind-viewer-actions/cluster-role-binding/actions.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/cluster-role-binding/actions.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import Ellipsis from '@lucide/svelte/icons/ellipsis';
+	import type { RbacAuthorizationK8SIoV1ClusterRoleBinding } from '@otterscale/types';
+	import type { Schema } from '@sjsf/form';
 	import type { ValidateFunction } from 'ajv';
 
 	import Delete from '$lib/components/kind-viewer/kind-viewer-actions/default/delete.svelte';
@@ -21,9 +23,9 @@
 		kind,
 		resource
 	}: {
-		schema: any;
+		schema: Schema;
 		validate: ValidateFunction;
-		object: any;
+		object: RbacAuthorizationK8SIoV1ClusterRoleBinding;
 		cluster: string;
 		group: string;
 		version: string;

--- a/src/lib/components/kind-viewer/kind-viewer-actions/cluster-role-binding/create.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/cluster-role-binding/create.svelte
@@ -2,6 +2,7 @@
 	import { ConnectError, createClient, type Transport } from '@connectrpc/connect';
 	import Plus from '@lucide/svelte/icons/plus';
 	import { ResourceService } from '@otterscale/api/resource/v1';
+	import type { RbacAuthorizationK8SIoV1ClusterRole } from '@otterscale/types';
 	import type { FormValue, Schema, UiSchemaRoot } from '@sjsf/form';
 	import { SubmitButton } from '@sjsf/form';
 	import Ajv from 'ajv';
@@ -32,7 +33,7 @@
 		showTrigger = true,
 		onsuccess
 	}: {
-		schema: any;
+		schema: Schema;
 		cluster: string;
 		group: string;
 		version: string;
@@ -47,15 +48,22 @@
 	const resourceClient = createClient(ResourceService, transport);
 
 	// Container for Data.
-	let values: any = $state({
-		apiVersion: group ? `${group}/${version}` : version,
-		kind,
-		metadata: { name: {} },
-		roleRef: { name: {} },
-		subjectKind: {},
-		subjects: {},
-		serviceAccount: {}
-	});
+	let values = $state(getInitialValues());
+
+	function getInitialValues() {
+		return {
+			apiVersion: group ? `${group}/${version}` : version,
+			kind,
+			metadata: { name: '' as string },
+			roleRef: { name: '' as string },
+			subjectKind: 'User' as string,
+			subjects: '' as string,
+			serviceAccount: {
+				name: '' as string,
+				namespace: '' as string
+			}
+		};
+	}
 
 	// Derived submission values (proper ClusterRoleBinding structure)
 	const submissionValues = $derived.by(() => {
@@ -129,9 +137,11 @@
 						resource: 'clusterroles'
 					});
 					const roles = response.items
-						.map((item: any) => (item.object as any)?.metadata?.name as string)
-						.filter((name: string) => name && name.toLowerCase().startsWith(search.toLowerCase()));
-					resolve(roles.map((name: string) => ({ label: name, value: name })));
+						.map(
+							(item) => (item.object as RbacAuthorizationK8SIoV1ClusterRole)?.metadata?.name ?? ''
+						)
+						.filter((name) => name && name.toLowerCase().startsWith(search.toLowerCase()));
+					resolve(roles.map((name) => ({ label: name, value: name })));
 				} catch (error) {
 					console.error('Error fetching cluster roles:', error);
 					resolve([]);
@@ -220,7 +230,7 @@
 			<Tabs.Content value={steps[0]}>
 				<Form
 					schema={{
-						...(lodash.get(jsonSchema, 'properties.metadata.properties.name') ?? {
+						...((lodash.get(jsonSchema, 'properties.metadata.properties.name') as Schema) ?? {
 							type: 'string'
 						}),
 						title: 'Name'

--- a/src/lib/components/kind-viewer/kind-viewer-actions/cluster-role-binding/update.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/cluster-role-binding/update.svelte
@@ -2,6 +2,10 @@
 	import { ConnectError, createClient, type Transport } from '@connectrpc/connect';
 	import FormIcon from '@lucide/svelte/icons/form';
 	import { ResourceService } from '@otterscale/api/resource/v1';
+	import type {
+		RbacAuthorizationK8SIoV1ClusterRole,
+		RbacAuthorizationK8SIoV1ClusterRoleBinding
+	} from '@otterscale/types';
 	import type { FormValue, Schema, UiSchemaRoot } from '@sjsf/form';
 	import { SubmitButton } from '@sjsf/form';
 	import Ajv from 'ajv';
@@ -31,8 +35,8 @@
 		resource,
 		onOpenChangeComplete
 	}: {
-		schema: any;
-		object: any;
+		schema: Schema;
+		object: RbacAuthorizationK8SIoV1ClusterRoleBinding;
 		cluster: string;
 		group: string;
 		version: string;
@@ -45,14 +49,21 @@
 	const resourceClient = createClient(ResourceService, transport);
 
 	// Container for Data.
-	let values: any = $state({
-		apiVersion: group ? `${group}/${version}` : version,
-		kind,
-		roleRef: { name: {} },
-		subjectKind: {},
-		subjects: {},
-		serviceAccount: {}
-	});
+	let values = $state(getInitialValues());
+
+	function getInitialValues() {
+		return {
+			apiVersion: group ? `${group}/${version}` : version,
+			kind,
+			roleRef: { name: '' as string },
+			subjectKind: 'User' as string,
+			subjects: '' as string,
+			serviceAccount: {
+				name: '' as string,
+				namespace: '' as string
+			}
+		};
+	}
 
 	// Derived submission values (proper ClusterRoleBinding structure)
 	const submissionValues = $derived.by(() => {
@@ -126,9 +137,11 @@
 						resource: 'clusterroles'
 					});
 					const roles = response.items
-						.map((item: any) => (item.object as any)?.metadata?.name as string)
-						.filter((name: string) => name && name.toLowerCase().includes(search.toLowerCase()));
-					resolve(roles.map((name: string) => ({ label: name, value: name })));
+						.map(
+							(item) => (item.object as RbacAuthorizationK8SIoV1ClusterRole)?.metadata?.name ?? ''
+						)
+						.filter((name) => name && name.toLowerCase().includes(search.toLowerCase()));
+					resolve(roles.map((name) => ({ label: name, value: name })));
 				} catch (error) {
 					console.error('Error fetching cluster roles:', error);
 					resolve([]);

--- a/src/lib/components/kind-viewer/kind-viewer-actions/cronjob/actions.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/cronjob/actions.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import Ellipsis from '@lucide/svelte/icons/ellipsis';
+	import type { BatchV1CronJob } from '@otterscale/types';
+	import type { Schema } from '@sjsf/form';
 	import type { ValidateFunction } from 'ajv';
 
 	import Delete from '$lib/components/kind-viewer/kind-viewer-actions/default/delete.svelte';
@@ -21,9 +23,9 @@
 		kind,
 		resource
 	}: {
-		schema: any;
+		schema: Schema;
 		validate: ValidateFunction;
-		object: any;
+		object: BatchV1CronJob;
 		cluster: string;
 		namespace: string;
 		group: string;

--- a/src/lib/components/kind-viewer/kind-viewer-actions/daemonset/actions.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/daemonset/actions.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import Ellipsis from '@lucide/svelte/icons/ellipsis';
+	import type { AppsV1DaemonSet } from '@otterscale/types';
+	import type { Schema } from '@sjsf/form';
 	import type { ValidateFunction } from 'ajv';
 
 	import Delete from '$lib/components/kind-viewer/kind-viewer-actions/default/delete.svelte';
@@ -23,9 +25,9 @@
 		kind,
 		resource
 	}: {
-		schema: any;
+		schema: Schema;
 		validate: ValidateFunction;
-		object: any;
+		object: AppsV1DaemonSet;
 		cluster: string;
 		namespace: string;
 		group: string;

--- a/src/lib/components/kind-viewer/kind-viewer-actions/data-volume/actions.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/data-volume/actions.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import Ellipsis from '@lucide/svelte/icons/ellipsis';
+	import type { CdiKubevirtIoV1Beta1DataVolume } from '@otterscale/types';
+	import type { Schema } from '@sjsf/form';
 
 	import Delete from '$lib/components/kind-viewer/kind-viewer-actions/default/delete.svelte';
 	import Describe from '$lib/components/kind-viewer/kind-viewer-actions/default/describe.svelte';
@@ -19,8 +21,8 @@
 		kind,
 		resource
 	}: {
-		schema: any;
-		object: any;
+		schema: Schema;
+		object: CdiKubevirtIoV1Beta1DataVolume;
 		cluster: string;
 		namespace: string;
 		group: string;

--- a/src/lib/components/kind-viewer/kind-viewer-actions/data-volume/create.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/data-volume/create.svelte
@@ -2,6 +2,11 @@
 	import { ConnectError, createClient, type Transport } from '@connectrpc/connect';
 	import { ExternalLink, Plus } from '@lucide/svelte';
 	import { ResourceService } from '@otterscale/api/resource/v1';
+	import type {
+		CoreV1Namespace,
+		CoreV1PersistentVolumeClaim,
+		StorageK8SIoV1StorageClass
+	} from '@otterscale/types';
 	import type { FormValue, Schema, UiSchemaRoot } from '@sjsf/form';
 	import { SubmitButton } from '@sjsf/form';
 	import Ajv from 'ajv';
@@ -33,7 +38,7 @@
 		showTrigger = true,
 		onsuccess
 	}: {
-		schema: any;
+		schema: Schema;
 		cluster: string;
 		namespace: string;
 		group: string;
@@ -49,37 +54,41 @@
 	const resourceClient = createClient(ResourceService, transport);
 
 	// Container for Data
-	let values: any = $state({
-		apiVersion: group ? `${group}/${version}` : version,
-		kind,
-		metadata: { name: {} },
-		sourceType: 'blank',
-		// Storage config
-		storageSize: '10Gi',
-		spec: {
-			source: {
-				http: {},
-				registry: {},
-				pvc: {},
-				s3: {},
-				gcs: {}
-			},
-			pvc: {
-				accessModes: '',
-				storageClassName: '',
-				volumeMode: ''
+	let values = $state(getInitialValues());
+
+	function getInitialValues() {
+		return {
+			apiVersion: group ? `${group}/${version}` : version,
+			kind,
+			metadata: { name: '' as string },
+			sourceType: 'blank' as string,
+			// Storage config
+			storageSize: '10Gi' as string,
+			spec: {
+				source: {
+					http: {} as FormValue,
+					registry: {} as FormValue,
+					pvc: {} as { namespace?: string; name?: string },
+					s3: {} as FormValue,
+					gcs: {} as FormValue
+				},
+				pvc: {
+					accessModes: '' as string,
+					storageClassName: '' as string,
+					volumeMode: '' as string
+				}
 			}
-		}
-	});
+		};
+	}
 
 	// Build source object based on selected source type
-	function buildSource(): Record<string, any> {
-		const st = values.sourceType as string;
+	function buildSource(): Record<string, unknown> {
+		const st = values.sourceType;
 		switch (st) {
 			case 'blank':
 				return { blank: {} };
-			case 'upload':
-				return { upload: {} };
+			// case 'upload':
+			// 	return { upload: {} };
 			case 'http':
 				return { http: values.spec.source.http };
 			case 'registry':
@@ -142,9 +151,9 @@
 				resource: 'storageclasses'
 			});
 			const names = response.items
-				.map((item: any) => (item.object as any)?.metadata?.name as string)
-				.filter((name: string) => name && name.toLowerCase().includes(search.toLowerCase()));
-			return names.map((name: string) => ({ label: name, value: name }));
+				.map((item) => (item.object as StorageK8SIoV1StorageClass)?.metadata?.name ?? '')
+				.filter((name) => name && name.toLowerCase().includes(search.toLowerCase()));
+			return names.map((name) => ({ label: name, value: name }));
 		} catch (error) {
 			console.error('Error fetching storage classes:', error);
 			return [];
@@ -156,7 +165,7 @@
 		search: string
 	): Promise<{ label: string; value: string }[]> {
 		try {
-			const ns = (values.spec.source.pvc.namespace as string) || namespace;
+			const ns = values.spec.source.pvc.namespace || namespace;
 			const response = await resourceClient.list({
 				cluster,
 				namespace: ns,
@@ -165,9 +174,9 @@
 				resource: 'persistentvolumeclaims'
 			});
 			const names = response.items
-				.map((item: any) => (item.object as any)?.metadata?.name as string)
-				.filter((name: string) => name && name.toLowerCase().includes(search.toLowerCase()));
-			return names.map((name: string) => ({ label: name, value: name }));
+				.map((item) => (item.object as CoreV1PersistentVolumeClaim)?.metadata?.name ?? '')
+				.filter((name) => name && name.toLowerCase().includes(search.toLowerCase()));
+			return names.map((name) => ({ label: name, value: name }));
 		} catch (error) {
 			console.error('Error fetching PVCs:', error);
 			return [];
@@ -186,9 +195,9 @@
 				resource: 'namespaces'
 			});
 			const names = response.items
-				.map((item: any) => (item.object as any)?.metadata?.name as string)
-				.filter((name: string) => name && name.toLowerCase().includes(search.toLowerCase()));
-			return names.map((name: string) => ({ label: name, value: name }));
+				.map((item) => (item.object as CoreV1Namespace)?.metadata?.name ?? '')
+				.filter((name) => name && name.toLowerCase().includes(search.toLowerCase()));
+			return names.map((name) => ({ label: name, value: name }));
 		} catch (error) {
 			console.error('Error fetching namespaces:', error);
 			return [];
@@ -199,7 +208,7 @@
 	let isSubmitting = $state(false);
 
 	// Reactive source type for conditional rendering
-	const sourceType = $derived(values.sourceType as string);
+	const sourceType = $derived(values.sourceType);
 </script>
 
 {#snippet externalLink()}
@@ -248,7 +257,7 @@
 			<Tabs.Content value={steps[0]}>
 				<Form
 					schema={{
-						...(lodash.get(jsonSchema, 'properties.metadata.properties.name') ?? {
+						...((lodash.get(jsonSchema, 'properties.metadata.properties.name') as Schema) ?? {
 							type: 'string'
 						}),
 						title: 'Name'
@@ -281,7 +290,7 @@
 					schema={{
 						type: 'string',
 						title: 'Source Type',
-						enum: ['blank', 'http', 'registry', 'pvc', 's3', 'gcs', 'upload']
+						enum: ['blank', 'http', 'registry', 'pvc', 's3', 'gcs' /*, 'upload'*/]
 					} as Schema}
 					uiSchema={{
 						'ui:components': {
@@ -317,14 +326,16 @@
 			</Tabs.Content>
 			<!-- Step 3: Source Details -->
 			<Tabs.Content value={steps[2]}>
-				{#if sourceType === 'blank' || sourceType === 'upload'}
+				{#if sourceType === 'blank' /* || sourceType === 'upload' */}
 					<div class="flex min-h-[50vh] flex-col gap-3">
 						<div class="flex flex-1 items-center justify-center text-sm text-muted-foreground">
 							{#if sourceType === 'blank'}
 								Empty volume — no source configuration needed.
+							{/if}
+							<!--
 							{:else}
 								Upload source selected — data will be uploaded after creation.
-							{/if}
+							-->
 						</div>
 						<div class="flex w-full items-center justify-between gap-3">
 							<Button
@@ -347,7 +358,10 @@
 					<Form
 						schema={{
 							...lodash.omit(
-								lodash.get(jsonSchema, 'properties.spec.properties.source.properties.http'),
+								lodash.get(
+									jsonSchema,
+									'properties.spec.properties.source.properties.http'
+								) as Schema,
 								'properties'
 							),
 							properties: {
@@ -355,7 +369,7 @@
 									lodash.get(
 										jsonSchema,
 										'properties.spec.properties.source.properties.http.properties'
-									),
+									) as Record<string, Schema>,
 									['url', 'secretRef', 'certConfigMap']
 								)
 							},
@@ -402,7 +416,10 @@
 					<Form
 						schema={{
 							...lodash.omit(
-								lodash.get(jsonSchema, 'properties.spec.properties.source.properties.registry'),
+								lodash.get(
+									jsonSchema,
+									'properties.spec.properties.source.properties.registry'
+								) as Schema,
 								'properties'
 							),
 							properties: {
@@ -410,7 +427,7 @@
 									lodash.get(
 										jsonSchema,
 										'properties.spec.properties.source.properties.registry.properties'
-									),
+									) as Record<string, Schema>,
 									['url', 'secretRef', 'pullMethod']
 								)
 							},
@@ -453,7 +470,10 @@
 					<Form
 						schema={{
 							...lodash.omit(
-								lodash.get(jsonSchema, 'properties.spec.properties.source.properties.pvc'),
+								lodash.get(
+									jsonSchema,
+									'properties.spec.properties.source.properties.pvc'
+								) as Schema,
 								'properties'
 							),
 							properties: {
@@ -461,7 +481,7 @@
 									lodash.get(
 										jsonSchema,
 										'properties.spec.properties.source.properties.pvc.properties'
-									),
+									) as Record<string, Schema>,
 									['name', 'namespace']
 								)
 							},
@@ -523,7 +543,7 @@
 					<Form
 						schema={{
 							...lodash.omit(
-								lodash.get(jsonSchema, 'properties.spec.properties.source.properties.s3'),
+								lodash.get(jsonSchema, 'properties.spec.properties.source.properties.s3') as Schema,
 								'properties'
 							),
 							properties: {
@@ -531,7 +551,7 @@
 									lodash.get(
 										jsonSchema,
 										'properties.spec.properties.source.properties.s3.properties'
-									),
+									) as Record<string, Schema>,
 									['url', 'secretRef']
 								)
 							},
@@ -569,7 +589,10 @@
 					<Form
 						schema={{
 							...lodash.omit(
-								lodash.get(jsonSchema, 'properties.spec.properties.source.properties.gcs'),
+								lodash.get(
+									jsonSchema,
+									'properties.spec.properties.source.properties.gcs'
+								) as Schema,
 								'properties'
 							),
 							properties: {
@@ -577,7 +600,7 @@
 									lodash.get(
 										jsonSchema,
 										'properties.spec.properties.source.properties.gcs.properties'
-									),
+									) as Record<string, Schema>,
 									['url', 'secretRef']
 								)
 							},
@@ -621,7 +644,7 @@
 							lodash.get(
 								jsonSchema,
 								'properties.spec.properties.pvc.properties.resources.properties.requests'
-							),
+							) as Schema,
 							'anyOf'
 						),
 						type: 'string',
@@ -660,25 +683,34 @@
 			<Tabs.Content value={steps[4]}>
 				<Form
 					schema={{
-						...lodash.omit(lodash.get(jsonSchema, 'properties.spec.properties.pvc'), 'properties'),
+						...lodash.omit(
+							lodash.get(jsonSchema, 'properties.spec.properties.pvc') as Schema,
+							'properties'
+						),
 						title: 'Storage',
 						properties: {
 							accessModes: {
 								...lodash.omit(
-									lodash.get(jsonSchema, 'properties.spec.properties.pvc.properties.accessModes'),
+									lodash.get(
+										jsonSchema,
+										'properties.spec.properties.pvc.properties.accessModes'
+									) as Schema,
 									['items', 'type']
 								),
 								enum: ['ReadWriteOnce', 'ReadWriteMany', 'ReadOnlyMany'],
 								title: 'Access Modes'
 							},
 							storageClassName: {
-								...lodash.get(
+								...(lodash.get(
 									jsonSchema,
 									'properties.spec.properties.pvc.properties.storageClassName'
-								)
+								) as Schema)
 							},
 							volumeMode: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.pvc.properties.volumeMode'),
+								...(lodash.get(
+									jsonSchema,
+									'properties.spec.properties.pvc.properties.volumeMode'
+								) as Schema),
 								enum: ['Filesystem', 'Block'],
 								title: 'Volume Mode'
 							}

--- a/src/lib/components/kind-viewer/kind-viewer-actions/data-volume/create.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/data-volume/create.svelte
@@ -326,7 +326,7 @@
 			</Tabs.Content>
 			<!-- Step 3: Source Details -->
 			<Tabs.Content value={steps[2]}>
-				{#if sourceType === 'blank' /* || sourceType === 'upload' */}
+				{#if sourceType === 'blank'}
 					<div class="flex min-h-[50vh] flex-col gap-3">
 						<div class="flex flex-1 items-center justify-center text-sm text-muted-foreground">
 							{#if sourceType === 'blank'}

--- a/src/lib/components/kind-viewer/kind-viewer-actions/data-volume/update.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/data-volume/update.svelte
@@ -327,7 +327,7 @@
 			</Tabs.Content>
 			<!-- Step 2: Source Details -->
 			<Tabs.Content value={steps[1]}>
-				{#if sourceType === 'blank' /* || sourceType === 'upload' */}
+				{#if sourceType === 'blank'}
 					<div class="flex min-h-[50vh] flex-col gap-3">
 						<div class="flex flex-1 items-center justify-center text-sm text-muted-foreground">
 							{#if sourceType === 'blank'}
@@ -544,10 +544,7 @@
 					<Form
 						schema={{
 							...lodash.omit(
-								lodash.get(
-									jsonSchema,
-									'properties.spec.properties.source.properties.s3'
-								) as Schema,
+								lodash.get(jsonSchema, 'properties.spec.properties.source.properties.s3') as Schema,
 								'properties'
 							),
 							properties: {

--- a/src/lib/components/kind-viewer/kind-viewer-actions/data-volume/update.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/data-volume/update.svelte
@@ -2,6 +2,12 @@
 	import { ConnectError, createClient, type Transport } from '@connectrpc/connect';
 	import { ExternalLink, FormIcon } from '@lucide/svelte';
 	import { ResourceService } from '@otterscale/api/resource/v1';
+	import type {
+		CdiKubevirtIoV1Beta1DataVolume,
+		CoreV1Namespace,
+		CoreV1PersistentVolumeClaim,
+		StorageK8SIoV1StorageClass
+	} from '@otterscale/types';
 	import type { FormValue, Schema, UiSchemaRoot } from '@sjsf/form';
 	import { SubmitButton } from '@sjsf/form';
 	import Ajv from 'ajv';
@@ -31,8 +37,8 @@
 		resource,
 		onOpenChangeComplete
 	}: {
-		schema: any;
-		object: any;
+		schema: Schema;
+		object: CdiKubevirtIoV1Beta1DataVolume;
 		cluster: string;
 		group: string;
 		version: string;
@@ -44,66 +50,81 @@
 	const transport: Transport = getContext('transport');
 	const resourceClient = createClient(ResourceService, transport);
 
-	// Extract existing values from object
-	const existingNamespace = lodash.get(object, 'metadata.namespace', '');
+	type LegacyStorageSpec = {
+		storage?: {
+			resources?: { requests?: { storage?: string | number } };
+			accessModes?: string[];
+			storageClassName?: string;
+			volumeMode?: string;
+		};
+	};
 
-	// Determine existing source type
-	const existingSource = lodash.get(object, 'spec.source', {});
-	const existingSourceType =
+	const existingNamespace = $derived(object.metadata?.namespace ?? '');
+	const existingSource = $derived((object.spec?.source ?? {}) as Record<string, unknown>);
+	const existingSourceType = $derived(
 		Object.keys(existingSource).find(
 			(k) => existingSource[k] && typeof existingSource[k] === 'object'
-		) ?? 'blank';
-
-	// Extract storage config
-	const existingStorageSize =
-		lodash.get(object, 'spec.pvc.resources.requests.storage') ??
-		lodash.get(object, 'spec.storage.resources.requests.storage') ??
-		'10Gi';
-	const existingAccessModes =
-		lodash.get(object, 'spec.pvc.accessModes') ??
-		lodash.get(object, 'spec.storage.accessModes') ??
-		[];
-	const existingAccessMode = existingAccessModes[0] ?? 'ReadWriteOnce';
-	const existingStorageClassName =
-		lodash.get(object, 'spec.pvc.storageClassName') ??
-		lodash.get(object, 'spec.storage.storageClassName') ??
-		'';
-	const existingVolumeMode =
-		lodash.get(object, 'spec.pvc.volumeMode') ??
-		lodash.get(object, 'spec.storage.volumeMode') ??
-		'Filesystem';
+		) ?? 'blank'
+	);
+	const existingStorageSize = $derived(
+		String(
+			object.spec?.pvc?.resources?.requests?.storage ??
+				(object.spec as LegacyStorageSpec | undefined)?.storage?.resources?.requests?.storage ??
+				'10Gi'
+		)
+	);
+	const existingAccessModes = $derived(
+		object.spec?.pvc?.accessModes ??
+			(object.spec as LegacyStorageSpec | undefined)?.storage?.accessModes ??
+			[]
+	);
+	const existingAccessMode = $derived(existingAccessModes[0] ?? 'ReadWriteOnce');
+	const existingStorageClassName = $derived(
+		object.spec?.pvc?.storageClassName ??
+			(object.spec as LegacyStorageSpec | undefined)?.storage?.storageClassName ??
+			''
+	);
+	const existingVolumeMode = $derived(
+		object.spec?.pvc?.volumeMode ??
+			(object.spec as LegacyStorageSpec | undefined)?.storage?.volumeMode ??
+			'Filesystem'
+	);
 
 	// Container for Data
-	let values: any = $state({
-		apiVersion: group ? `${group}/${version}` : version,
-		kind,
-		sourceType: existingSourceType,
-		// Storage config
-		storageSize: existingStorageSize,
-		spec: {
-			source: {
-				http: existingSource.http ?? {},
-				registry: existingSource.registry ?? {},
-				pvc: existingSource.pvc ?? {},
-				s3: existingSource.s3 ?? {},
-				gcs: existingSource.gcs ?? {}
-			},
-			pvc: {
-				accessModes: existingAccessMode,
-				storageClassName: existingStorageClassName,
-				volumeMode: existingVolumeMode
+	let values = $state(getInitialValues());
+
+	function getInitialValues() {
+		return {
+			apiVersion: group ? `${group}/${version}` : version,
+			kind,
+			sourceType: existingSourceType,
+			// Storage config
+			storageSize: existingStorageSize,
+			spec: {
+				source: {
+					http: (existingSource.http ?? {}) as FormValue,
+					registry: (existingSource.registry ?? {}) as FormValue,
+					pvc: (existingSource.pvc ?? {}) as { namespace?: string; name?: string },
+					s3: (existingSource.s3 ?? {}) as FormValue,
+					gcs: (existingSource.gcs ?? {}) as FormValue
+				},
+				pvc: {
+					accessModes: existingAccessMode,
+					storageClassName: existingStorageClassName,
+					volumeMode: existingVolumeMode
+				}
 			}
-		}
-	});
+		};
+	}
 
 	// Build source object based on selected source type
-	function buildSource(): Record<string, any> {
-		const st = values.sourceType as string;
+	function buildSource(): Record<string, unknown> {
+		const st = values.sourceType;
 		switch (st) {
 			case 'blank':
 				return { blank: {} };
-			case 'upload':
-				return { upload: {} };
+			// case 'upload':
+			// 	return { upload: {} };
 			case 'http':
 				return { http: values.spec.source.http };
 			case 'registry':
@@ -124,7 +145,7 @@
 		apiVersion: group ? `${group}/${version}` : version,
 		kind,
 		metadata: {
-			name: lodash.get(object, 'metadata.name'),
+			name: object.metadata?.name,
 			namespace: existingNamespace
 		},
 		spec: {
@@ -166,9 +187,9 @@
 				resource: 'storageclasses'
 			});
 			const names = response.items
-				.map((item: any) => (item.object as any)?.metadata?.name as string)
-				.filter((name: string) => name && name.toLowerCase().includes(search.toLowerCase()));
-			return names.map((name: string) => ({ label: name, value: name }));
+				.map((item) => (item.object as StorageK8SIoV1StorageClass)?.metadata?.name ?? '')
+				.filter((name) => name && name.toLowerCase().includes(search.toLowerCase()));
+			return names.map((name) => ({ label: name, value: name }));
 		} catch (error) {
 			console.error('Error fetching storage classes:', error);
 			return [];
@@ -180,7 +201,7 @@
 		search: string
 	): Promise<{ label: string; value: string }[]> {
 		try {
-			const ns = (values.spec.source.pvc.namespace as string) || existingNamespace;
+			const ns = values.spec.source.pvc.namespace || existingNamespace;
 			const response = await resourceClient.list({
 				cluster,
 				namespace: ns,
@@ -189,9 +210,9 @@
 				resource: 'persistentvolumeclaims'
 			});
 			const names = response.items
-				.map((item: any) => (item.object as any)?.metadata?.name as string)
-				.filter((name: string) => name && name.toLowerCase().includes(search.toLowerCase()));
-			return names.map((name: string) => ({ label: name, value: name }));
+				.map((item) => (item.object as CoreV1PersistentVolumeClaim)?.metadata?.name ?? '')
+				.filter((name) => name && name.toLowerCase().includes(search.toLowerCase()));
+			return names.map((name) => ({ label: name, value: name }));
 		} catch (error) {
 			console.error('Error fetching PVCs:', error);
 			return [];
@@ -210,9 +231,9 @@
 				resource: 'namespaces'
 			});
 			const names = response.items
-				.map((item: any) => (item.object as any)?.metadata?.name as string)
-				.filter((name: string) => name && name.toLowerCase().includes(search.toLowerCase()));
-			return names.map((name: string) => ({ label: name, value: name }));
+				.map((item) => (item.object as CoreV1Namespace)?.metadata?.name ?? '')
+				.filter((name) => name && name.toLowerCase().includes(search.toLowerCase()));
+			return names.map((name) => ({ label: name, value: name }));
 		} catch (error) {
 			console.error('Error fetching namespaces:', error);
 			return [];
@@ -224,7 +245,7 @@
 	let isSubmitting = $state(false);
 
 	// Reactive source type for conditional rendering
-	const sourceType = $derived(values.sourceType as string);
+	const sourceType = $derived(values.sourceType);
 </script>
 
 {#snippet externalLink()}
@@ -277,7 +298,7 @@
 					schema={{
 						type: 'string',
 						title: 'Source Type',
-						enum: ['blank', 'http', 'registry', 'pvc', 's3', 'gcs', 'upload']
+						enum: ['blank', 'http', 'registry', 'pvc', 's3', 'gcs' /*, 'upload'*/]
 					} as Schema}
 					uiSchema={{
 						'ui:components': {
@@ -306,14 +327,16 @@
 			</Tabs.Content>
 			<!-- Step 2: Source Details -->
 			<Tabs.Content value={steps[1]}>
-				{#if sourceType === 'blank' || sourceType === 'upload'}
+				{#if sourceType === 'blank' /* || sourceType === 'upload' */}
 					<div class="flex min-h-[50vh] flex-col gap-3">
 						<div class="flex flex-1 items-center justify-center text-sm text-muted-foreground">
 							{#if sourceType === 'blank'}
 								Empty volume — no source configuration needed.
+							{/if}
+							<!--
 							{:else}
 								Upload source selected — data will be uploaded after creation.
-							{/if}
+							-->
 						</div>
 						<div class="flex w-full items-center justify-between gap-3">
 							<Button
@@ -336,7 +359,10 @@
 					<Form
 						schema={{
 							...lodash.omit(
-								lodash.get(jsonSchema, 'properties.spec.properties.source.properties.http'),
+								lodash.get(
+									jsonSchema,
+									'properties.spec.properties.source.properties.http'
+								) as Schema,
 								'properties'
 							),
 							properties: {
@@ -344,7 +370,7 @@
 									lodash.get(
 										jsonSchema,
 										'properties.spec.properties.source.properties.http.properties'
-									),
+									) as Record<string, Schema>,
 									['url', 'secretRef', 'certConfigMap']
 								)
 							},
@@ -391,7 +417,10 @@
 					<Form
 						schema={{
 							...lodash.omit(
-								lodash.get(jsonSchema, 'properties.spec.properties.source.properties.registry'),
+								lodash.get(
+									jsonSchema,
+									'properties.spec.properties.source.properties.registry'
+								) as Schema,
 								'properties'
 							),
 							properties: {
@@ -399,7 +428,7 @@
 									lodash.get(
 										jsonSchema,
 										'properties.spec.properties.source.properties.registry.properties'
-									),
+									) as Record<string, Schema>,
 									['url', 'secretRef', 'pullMethod']
 								)
 							},
@@ -442,7 +471,10 @@
 					<Form
 						schema={{
 							...lodash.omit(
-								lodash.get(jsonSchema, 'properties.spec.properties.source.properties.pvc'),
+								lodash.get(
+									jsonSchema,
+									'properties.spec.properties.source.properties.pvc'
+								) as Schema,
 								'properties'
 							),
 							properties: {
@@ -450,7 +482,7 @@
 									lodash.get(
 										jsonSchema,
 										'properties.spec.properties.source.properties.pvc.properties'
-									),
+									) as Record<string, Schema>,
 									['name', 'namespace']
 								)
 							},
@@ -512,7 +544,10 @@
 					<Form
 						schema={{
 							...lodash.omit(
-								lodash.get(jsonSchema, 'properties.spec.properties.source.properties.s3'),
+								lodash.get(
+									jsonSchema,
+									'properties.spec.properties.source.properties.s3'
+								) as Schema,
 								'properties'
 							),
 							properties: {
@@ -520,7 +555,7 @@
 									lodash.get(
 										jsonSchema,
 										'properties.spec.properties.source.properties.s3.properties'
-									),
+									) as Record<string, Schema>,
 									['url', 'secretRef']
 								)
 							},
@@ -558,7 +593,10 @@
 					<Form
 						schema={{
 							...lodash.omit(
-								lodash.get(jsonSchema, 'properties.spec.properties.source.properties.gcs'),
+								lodash.get(
+									jsonSchema,
+									'properties.spec.properties.source.properties.gcs'
+								) as Schema,
 								'properties'
 							),
 							properties: {
@@ -566,7 +604,7 @@
 									lodash.get(
 										jsonSchema,
 										'properties.spec.properties.source.properties.gcs.properties'
-									),
+									) as Record<string, Schema>,
 									['url', 'secretRef']
 								)
 							},
@@ -610,7 +648,7 @@
 							lodash.get(
 								jsonSchema,
 								'properties.spec.properties.pvc.properties.resources.properties.requests'
-							),
+							) as Schema,
 							'anyOf'
 						),
 						type: 'string',
@@ -649,25 +687,34 @@
 			<Tabs.Content value={steps[3]}>
 				<Form
 					schema={{
-						...lodash.omit(lodash.get(jsonSchema, 'properties.spec.properties.pvc'), 'properties'),
+						...lodash.omit(
+							lodash.get(jsonSchema, 'properties.spec.properties.pvc') as Schema,
+							'properties'
+						),
 						title: 'Storage',
 						properties: {
 							accessModes: {
 								...lodash.omit(
-									lodash.get(jsonSchema, 'properties.spec.properties.pvc.properties.accessModes'),
+									lodash.get(
+										jsonSchema,
+										'properties.spec.properties.pvc.properties.accessModes'
+									) as Schema,
 									['items', 'type']
 								),
 								enum: ['ReadWriteOnce', 'ReadWriteMany', 'ReadOnlyMany'],
 								title: 'Access Modes'
 							},
 							storageClassName: {
-								...lodash.get(
+								...(lodash.get(
 									jsonSchema,
 									'properties.spec.properties.pvc.properties.storageClassName'
-								)
+								) as Schema)
 							},
 							volumeMode: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.pvc.properties.volumeMode'),
+								...(lodash.get(
+									jsonSchema,
+									'properties.spec.properties.pvc.properties.volumeMode'
+								) as Schema),
 								enum: ['Filesystem', 'Block'],
 								title: 'Volume Mode'
 							}

--- a/src/lib/components/kind-viewer/kind-viewer-actions/deployment/actions.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/deployment/actions.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import Ellipsis from '@lucide/svelte/icons/ellipsis';
+	import type { AppsV1Deployment } from '@otterscale/types';
+	import type { Schema } from '@sjsf/form';
 	import type { ValidateFunction } from 'ajv';
 
 	import Delete from '$lib/components/kind-viewer/kind-viewer-actions/default/delete.svelte';
@@ -24,9 +26,9 @@
 		kind,
 		resource
 	}: {
-		schema: any;
+		schema: Schema;
 		validate: ValidateFunction;
-		object: any;
+		object: AppsV1Deployment;
 		cluster: string;
 		namespace: string;
 		group: string;

--- a/src/lib/components/kind-viewer/kind-viewer-actions/instance-type/actions.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/instance-type/actions.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import Ellipsis from '@lucide/svelte/icons/ellipsis';
+	import type { InstancetypeKubevirtIoV1Beta1VirtualMachineInstancetype } from '@otterscale/types';
+	import type { Schema } from '@sjsf/form';
 
 	import Delete from '$lib/components/kind-viewer/kind-viewer-actions/default/delete.svelte';
 	import Describe from '$lib/components/kind-viewer/kind-viewer-actions/default/describe.svelte';
@@ -19,8 +21,8 @@
 		kind,
 		resource
 	}: {
-		schema: any;
-		object: any;
+		schema: Schema;
+		object: InstancetypeKubevirtIoV1Beta1VirtualMachineInstancetype;
 		cluster: string;
 		namespace: string;
 		group: string;

--- a/src/lib/components/kind-viewer/kind-viewer-actions/instance-type/create.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/instance-type/create.svelte
@@ -32,7 +32,7 @@
 		showTrigger = true,
 		onsuccess
 	}: {
-		schema: any;
+		schema: Schema;
 		cluster: string;
 		namespace: string;
 		group: string;
@@ -48,16 +48,20 @@
 	const resourceClient = createClient(ResourceService, transport);
 
 	// Container for Data
-	let values: any = $state({
-		apiVersion: group ? `${group}/${version}` : version,
-		kind,
-		metadata: { name: {} },
-		spec: {
-			cpu: { guest: 1 },
-			memory: { guest: '1Gi' }
-		}
-	});
+	let values = $state(getInitialValues());
 	let value = $derived(stringify(values));
+
+	function getInitialValues() {
+		return {
+			apiVersion: group ? `${group}/${version}` : version,
+			kind,
+			metadata: { name: '' as string },
+			spec: {
+				cpu: { guest: 1 as number },
+				memory: { guest: '1Gi' as string }
+			}
+		};
+	}
 
 	// Steps Manager
 	const steps = Array.from({ length: 4 }, (_, index) => String(index + 1));
@@ -113,7 +117,7 @@
 			<Tabs.Content value={steps[0]}>
 				<Form
 					schema={{
-						...(lodash.get(jsonSchema, 'properties.metadata.properties.name') ?? {
+						...((lodash.get(jsonSchema, 'properties.metadata.properties.name') as Schema) ?? {
 							type: 'string'
 						}),
 						title: 'Name'
@@ -144,7 +148,7 @@
 			<Tabs.Content value={steps[1]}>
 				<Form
 					schema={{
-						...lodash.get(jsonSchema, 'properties.spec.properties.cpu.properties.guest'),
+						...(lodash.get(jsonSchema, 'properties.spec.properties.cpu.properties.guest') as Schema),
 						title: 'CPU'
 					} as Schema}
 					uiSchema={{
@@ -181,7 +185,7 @@
 				<Form
 					schema={{
 						...lodash.omit(
-							lodash.get(jsonSchema, 'properties.spec.properties.memory.properties.guest'),
+							lodash.get(jsonSchema, 'properties.spec.properties.memory.properties.guest') as Schema,
 							'anyOf'
 						),
 						type: 'string',

--- a/src/lib/components/kind-viewer/kind-viewer-actions/instance-type/create.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/instance-type/create.svelte
@@ -148,7 +148,10 @@
 			<Tabs.Content value={steps[1]}>
 				<Form
 					schema={{
-						...(lodash.get(jsonSchema, 'properties.spec.properties.cpu.properties.guest') as Schema),
+						...(lodash.get(
+							jsonSchema,
+							'properties.spec.properties.cpu.properties.guest'
+						) as Schema),
 						title: 'CPU'
 					} as Schema}
 					uiSchema={{
@@ -185,7 +188,10 @@
 				<Form
 					schema={{
 						...lodash.omit(
-							lodash.get(jsonSchema, 'properties.spec.properties.memory.properties.guest') as Schema,
+							lodash.get(
+								jsonSchema,
+								'properties.spec.properties.memory.properties.guest'
+							) as Schema,
 							'anyOf'
 						),
 						type: 'string',

--- a/src/lib/components/kind-viewer/kind-viewer-actions/instance-type/update.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/instance-type/update.svelte
@@ -121,7 +121,10 @@
 			<Tabs.Content value={steps[0]}>
 				<Form
 					schema={{
-						...(lodash.get(jsonSchema, 'properties.spec.properties.cpu.properties.guest') as Schema),
+						...(lodash.get(
+							jsonSchema,
+							'properties.spec.properties.cpu.properties.guest'
+						) as Schema),
 						title: 'CPU'
 					} as Schema}
 					uiSchema={{
@@ -151,7 +154,10 @@
 				<Form
 					schema={{
 						...lodash.omit(
-							lodash.get(jsonSchema, 'properties.spec.properties.memory.properties.guest') as Schema,
+							lodash.get(
+								jsonSchema,
+								'properties.spec.properties.memory.properties.guest'
+							) as Schema,
 							'anyOf'
 						),
 						type: 'string',

--- a/src/lib/components/kind-viewer/kind-viewer-actions/instance-type/update.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/instance-type/update.svelte
@@ -2,6 +2,7 @@
 	import { ConnectError, createClient, type Transport } from '@connectrpc/connect';
 	import { FormIcon } from '@lucide/svelte';
 	import { ResourceService } from '@otterscale/api/resource/v1';
+	import type { InstancetypeKubevirtIoV1Beta1VirtualMachineInstancetype } from '@otterscale/types';
 	import type { FormValue, Schema, UiSchemaRoot } from '@sjsf/form';
 	import { SubmitButton } from '@sjsf/form';
 	import Ajv from 'ajv';
@@ -30,8 +31,8 @@
 		resource,
 		onOpenChangeComplete
 	}: {
-		schema: any;
-		object: any;
+		schema: Schema;
+		object: InstancetypeKubevirtIoV1Beta1VirtualMachineInstancetype;
 		cluster: string;
 		group: string;
 		version: string;
@@ -43,26 +44,28 @@
 	const transport: Transport = getContext('transport');
 	const resourceClient = createClient(ResourceService, transport);
 
-	// Extract existing values from object
-	const existingNamespace = lodash.get(object, 'metadata.namespace', '');
-	const existingName = lodash.get(object, 'metadata.name', '');
-	const existingCpuGuest = lodash.get(object, 'spec.cpu.guest', 1);
-	const existingMemoryGuest = lodash.get(object, 'spec.memory.guest', '1Gi');
+	const existingNamespace = $derived(object.metadata?.namespace ?? '');
+	const existingCpuGuest = $derived(object.spec?.cpu?.guest ?? 1);
+	const existingMemoryGuest = $derived(String(object.spec?.memory?.guest ?? '1Gi'));
 
 	// Container for Data
-	let values: any = $state({
-		apiVersion: group ? `${group}/${version}` : version,
-		kind,
-		metadata: {
-			name: existingName,
-			namespace: existingNamespace
-		},
-		spec: {
-			cpu: { guest: existingCpuGuest },
-			memory: { guest: existingMemoryGuest }
-		}
-	});
+	let values = $state(getInitialValues());
 	let value = $derived(stringify(values));
+
+	function getInitialValues() {
+		return {
+			apiVersion: group ? `${group}/${version}` : version,
+			kind,
+			metadata: {
+				name: object.metadata?.name ?? '',
+				namespace: existingNamespace
+			},
+			spec: {
+				cpu: { guest: existingCpuGuest as number },
+				memory: { guest: existingMemoryGuest }
+			}
+		};
+	}
 
 	// Steps Manager
 	const steps = Array.from({ length: 3 }, (_, index) => String(index + 1));
@@ -118,7 +121,7 @@
 			<Tabs.Content value={steps[0]}>
 				<Form
 					schema={{
-						...lodash.get(jsonSchema, 'properties.spec.properties.cpu.properties.guest'),
+						...(lodash.get(jsonSchema, 'properties.spec.properties.cpu.properties.guest') as Schema),
 						title: 'CPU'
 					} as Schema}
 					uiSchema={{
@@ -148,7 +151,7 @@
 				<Form
 					schema={{
 						...lodash.omit(
-							lodash.get(jsonSchema, 'properties.spec.properties.memory.properties.guest'),
+							lodash.get(jsonSchema, 'properties.spec.properties.memory.properties.guest') as Schema,
 							'anyOf'
 						),
 						type: 'string',

--- a/src/lib/components/kind-viewer/kind-viewer-actions/job/actions.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/job/actions.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import Ellipsis from '@lucide/svelte/icons/ellipsis';
+	import type { BatchV1Job } from '@otterscale/types';
+	import type { Schema } from '@sjsf/form';
 	import type { ValidateFunction } from 'ajv';
 
 	import Delete from '$lib/components/kind-viewer/kind-viewer-actions/default/delete.svelte';
@@ -21,9 +23,9 @@
 		kind,
 		resource
 	}: {
-		schema: any;
+		schema: Schema;
 		validate: ValidateFunction;
-		object: any;
+		object: BatchV1Job;
 		cluster: string;
 		namespace: string;
 		group: string;

--- a/src/lib/components/kind-viewer/kind-viewer-actions/pod/actions.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/pod/actions.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import Ellipsis from '@lucide/svelte/icons/ellipsis';
+	import type { CoreV1Pod } from '@otterscale/types';
+	import type { Schema } from '@sjsf/form';
 	import type { ValidateFunction } from 'ajv';
 
 	import Delete from '$lib/components/kind-viewer/kind-viewer-actions/default/delete.svelte';
@@ -23,9 +25,9 @@
 		kind,
 		resource
 	}: {
-		schema: any;
+		schema: Schema;
 		validate: ValidateFunction;
-		object: any;
+		object: CoreV1Pod;
 		cluster: string;
 		namespace: string;
 		group: string;

--- a/src/lib/components/kind-viewer/kind-viewer-actions/resource-quota/actions.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/resource-quota/actions.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import Ellipsis from '@lucide/svelte/icons/ellipsis';
+	import type { CoreV1ResourceQuota } from '@otterscale/types';
+	import type { Schema } from '@sjsf/form';
 	import type { ValidateFunction } from 'ajv';
 
 	import Delete from '$lib/components/kind-viewer/kind-viewer-actions/default/delete.svelte';
@@ -26,9 +28,9 @@
 		version: string;
 		kind: string;
 		resource: string;
-		schema: any;
+		schema: Schema;
 		validate: ValidateFunction;
-		object: any;
+		object: CoreV1ResourceQuota;
 	} = $props();
 
 	let actionsOpen = $state(false);

--- a/src/lib/components/kind-viewer/kind-viewer-actions/schedule/actions.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/schedule/actions.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import Ellipsis from '@lucide/svelte/icons/ellipsis';
+	import type { Schema } from '@sjsf/form';
 
 	import Delete from '$lib/components/kind-viewer/kind-viewer-actions/default/delete.svelte';
 	import Describe from '$lib/components/kind-viewer/kind-viewer-actions/default/describe.svelte';
@@ -19,8 +20,8 @@
 		kind,
 		resource
 	}: {
-		schema: any;
-		object: any;
+		schema: Schema;
+		object: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 		cluster: string;
 		namespace: string;
 		group: string;

--- a/src/lib/components/kind-viewer/kind-viewer-actions/schedule/create.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/schedule/create.svelte
@@ -36,7 +36,7 @@
 		version: string;
 		kind: string;
 		resource: string;
-		schema?: any;
+		schema?: Schema;
 		onOpenChangeComplete: () => void;
 	} = $props();
 
@@ -47,21 +47,29 @@
 		allErrors: true,
 		strict: false
 	});
-	const validate = jsonSchemaValidator.compile(jsonSchema);
+	const validate = $derived(jsonSchemaValidator.compile(jsonSchema ?? {}));
 
 	// Container for Data — flat structure matching quickCronjob RGD schema
-	let values: any = $state({
-		apiVersion: group ? `${group}/${version}` : version,
-		kind,
-		metadata: {},
-		spec: {}
-	});
-	let settingsValues: any = $state({});
-	let specValues: any = $state({});
-	let resourceValues: any = $state({});
+	let values = $state(getInitialValues());
+	let settingsValues = $state<FormValue>({});
+	let specValues = $state<FormValue>({});
+	let resourceValues = $state<FormValue>({});
+
+	function getInitialValues() {
+		return {
+			apiVersion: group ? `${group}/${version}` : version,
+			kind,
+			metadata: {} as { name?: string; namespace?: string },
+			spec: {} as FormValue
+		};
+	}
 
 	$effect(() => {
-		values.spec = { ...settingsValues, ...specValues, ...resourceValues };
+		values.spec = {
+			...(settingsValues as Record<string, unknown>),
+			...(specValues as Record<string, unknown>),
+			...(resourceValues as Record<string, unknown>)
+		} as FormValue;
 	});
 
 	let value = $derived(stringify(values));
@@ -118,18 +126,18 @@
 			<Tabs.Content value={steps[0]}>
 				<Form
 					schema={{
-						...(lodash.omit(lodash.get(jsonSchema, 'properties.metadata'), 'properties') as Record<
-							string,
-							unknown
-						>),
+						...lodash.omit(
+							lodash.get(jsonSchema, 'properties.metadata') as Schema,
+							'properties'
+						),
 						title: 'Metadata',
 						properties: {
 							name: {
-								...lodash.get(jsonSchema, 'properties.metadata.properties.name'),
+								...(lodash.get(jsonSchema, 'properties.metadata.properties.name') as Schema),
 								title: 'Name'
 							},
 							namespace: {
-								...lodash.get(jsonSchema, 'properties.metadata.properties.namespace'),
+								...(lodash.get(jsonSchema, 'properties.metadata.properties.namespace') as Schema),
 								title: 'Namespace',
 								readOnly: true
 							}
@@ -171,27 +179,36 @@
 				<Form
 					schema={{
 						title: 'Setting',
-						...lodash.omit(lodash.get(jsonSchema, 'properties.spec'), 'properties'),
+						...lodash.omit(lodash.get(jsonSchema, 'properties.spec') as Schema, 'properties'),
 						properties: {
 							concurrencyPolicy: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.concurrencyPolicy'),
+								...(lodash.get(
+									jsonSchema,
+									'properties.spec.properties.concurrencyPolicy'
+								) as Schema),
 								title: 'Concurrency Policy',
 								enum: ['Allow', 'Forbid', 'Replace']
 							},
 							suspend: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.suspend'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.suspend') as Schema),
 								title: 'Suspend'
 							},
 							successfulJobsHistoryLimit: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.successfulJobsHistoryLimit'),
+								...(lodash.get(
+									jsonSchema,
+									'properties.spec.properties.successfulJobsHistoryLimit'
+								) as Schema),
 								title: 'Successful Jobs History Limit'
 							},
 							failedJobsHistoryLimit: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.failedJobsHistoryLimit'),
+								...(lodash.get(
+									jsonSchema,
+									'properties.spec.properties.failedJobsHistoryLimit'
+								) as Schema),
 								title: 'Failed Jobs History Limit'
 							},
 							restartPolicy: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.restartPolicy'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.restartPolicy') as Schema),
 								title: 'Restart Policy',
 								enum: ['OnFailure', 'Never']
 							}
@@ -264,32 +281,32 @@
 					schema={{
 						title: 'Container',
 						type: 'object',
-						required: lodash
-							.get(jsonSchema, 'properties.spec.required', [])
-							.filter((f: string) => ['name', 'image', 'cronSchedule'].includes(f)),
+						required: (
+							lodash.get(jsonSchema, 'properties.spec.required', []) as string[]
+						).filter((f) => ['name', 'image', 'cronSchedule'].includes(f)),
 						properties: {
 							name: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.name'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.name') as Schema),
 								title: 'Name'
 							},
 							image: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.image'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.image') as Schema),
 								title: 'Image'
 							},
 							command: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.command'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.command') as Schema),
 								title: 'Command'
 							},
 							args: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.args'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.args') as Schema),
 								title: 'Arguments'
 							},
 							cronSchedule: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.cronSchedule'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.cronSchedule') as Schema),
 								title: 'Cron Schedule'
 							},
 							containerPort: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.containerPort'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.containerPort') as Schema),
 								title: 'Container Port'
 							}
 						}
@@ -312,7 +329,7 @@
 						}
 					} as UiSchemaRoot}
 					initialValue={{
-						name: values.metadata?.name ?? null,
+						name: values.metadata.name ?? null,
 						image: null,
 						cronSchedule: '*/5 * * * *',
 						containerPort: 8080
@@ -347,27 +364,42 @@
 						type: 'object',
 						properties: {
 							resourcesRequestsCpu: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.resourcesRequestsCpu'),
+								...(lodash.get(
+									jsonSchema,
+									'properties.spec.properties.resourcesRequestsCpu'
+								) as Schema),
 								title: 'CPU Request'
 							},
 							resourcesRequestsMemory: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.resourcesRequestsMemory'),
+								...(lodash.get(
+									jsonSchema,
+									'properties.spec.properties.resourcesRequestsMemory'
+								) as Schema),
 								title: 'Memory Request'
 							},
 							resourcesLimitsCpu: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.resourcesLimitsCpu'),
+								...(lodash.get(
+									jsonSchema,
+									'properties.spec.properties.resourcesLimitsCpu'
+								) as Schema),
 								title: 'CPU Limit'
 							},
 							resourcesLimitsMemory: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.resourcesLimitsMemory'),
+								...(lodash.get(
+									jsonSchema,
+									'properties.spec.properties.resourcesLimitsMemory'
+								) as Schema),
 								title: 'Memory Limit'
 							},
 							resourcesGpu: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.resourcesGpu'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.resourcesGpu') as Schema),
 								title: 'GPU'
 							},
 							resourcesGpumem: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.resourcesGpumem'),
+								...(lodash.get(
+									jsonSchema,
+									'properties.spec.properties.resourcesGpumem'
+								) as Schema),
 								title: 'GPU Memory'
 							}
 						}
@@ -437,7 +469,7 @@
 
 							isSubmitting = true;
 
-							let parsed: any;
+							let parsed: unknown;
 							try {
 								parsed = load(value);
 							} catch {

--- a/src/lib/components/kind-viewer/kind-viewer-actions/schedule/create.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/schedule/create.svelte
@@ -126,10 +126,7 @@
 			<Tabs.Content value={steps[0]}>
 				<Form
 					schema={{
-						...lodash.omit(
-							lodash.get(jsonSchema, 'properties.metadata') as Schema,
-							'properties'
-						),
+						...lodash.omit(lodash.get(jsonSchema, 'properties.metadata') as Schema, 'properties'),
 						title: 'Metadata',
 						properties: {
 							name: {
@@ -281,9 +278,9 @@
 					schema={{
 						title: 'Container',
 						type: 'object',
-						required: (
-							lodash.get(jsonSchema, 'properties.spec.required', []) as string[]
-						).filter((f) => ['name', 'image', 'cronSchedule'].includes(f)),
+						required: (lodash.get(jsonSchema, 'properties.spec.required', []) as string[]).filter(
+							(f) => ['name', 'image', 'cronSchedule'].includes(f)
+						),
 						properties: {
 							name: {
 								...(lodash.get(jsonSchema, 'properties.spec.properties.name') as Schema),
@@ -396,10 +393,7 @@
 								title: 'GPU'
 							},
 							resourcesGpumem: {
-								...(lodash.get(
-									jsonSchema,
-									'properties.spec.properties.resourcesGpumem'
-								) as Schema),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.resourcesGpumem') as Schema),
 								title: 'GPU Memory'
 							}
 						}

--- a/src/lib/components/kind-viewer/kind-viewer-actions/schedule/update.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/schedule/update.svelte
@@ -276,9 +276,9 @@
 					schema={{
 						title: 'Container',
 						type: 'object',
-						required: (
-							lodash.get(jsonSchema, 'properties.spec.required', []) as string[]
-						).filter((f) => ['name', 'image', 'cronSchedule'].includes(f)),
+						required: (lodash.get(jsonSchema, 'properties.spec.required', []) as string[]).filter(
+							(f) => ['name', 'image', 'cronSchedule'].includes(f)
+						),
 						properties: {
 							name: {
 								...(lodash.get(jsonSchema, 'properties.spec.properties.name') as Schema),
@@ -394,10 +394,7 @@
 								title: 'GPU'
 							},
 							resourcesGpumem: {
-								...(lodash.get(
-									jsonSchema,
-									'properties.spec.properties.resourcesGpumem'
-								) as Schema),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.resourcesGpumem') as Schema),
 								title: 'GPU Memory'
 							}
 						}

--- a/src/lib/components/kind-viewer/kind-viewer-actions/schedule/update.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/schedule/update.svelte
@@ -35,10 +35,35 @@
 		version: string;
 		kind: string;
 		resource: string;
-		schema: any;
-		object: any;
+		schema: Schema;
+		object: ScheduleObject;
 		onOpenChangeComplete: () => void;
 	} = $props();
+
+	type ScheduleSpec = {
+		name?: string;
+		image?: string;
+		command?: string[];
+		args?: string[];
+		cronSchedule?: string;
+		containerPort?: number;
+		concurrencyPolicy?: string;
+		suspend?: boolean;
+		successfulJobsHistoryLimit?: number;
+		failedJobsHistoryLimit?: number;
+		restartPolicy?: string;
+		resourcesRequestsCpu?: string;
+		resourcesRequestsMemory?: string;
+		resourcesLimitsCpu?: string;
+		resourcesLimitsMemory?: string;
+		resourcesGpu?: string;
+		resourcesGpumem?: string;
+	};
+
+	type ScheduleObject = {
+		metadata?: { name?: string; namespace?: string; [k: string]: unknown };
+		spec?: ScheduleSpec;
+	};
 
 	const transport: Transport = getContext('transport');
 	const resourceClient = createClient(ResourceService, transport);
@@ -61,27 +86,33 @@
 		'uid'
 	];
 
-	let values: any = $state({
-		apiVersion: group ? `${group}/${version}` : version,
-		kind,
-		metadata: object.metadata,
-		spec: {}
-	});
-	let settingsValues: any = $state({});
-	let specValues: any = $state({});
-	let resourceValues: any = $state({});
+	let values = $state(getInitialValues());
+	let settingsValues = $state<FormValue>({});
+	let specValues = $state<FormValue>({});
+	let resourceValues = $state<FormValue>({});
+
+	function getInitialValues() {
+		return {
+			apiVersion: group ? `${group}/${version}` : version,
+			kind,
+			metadata: (object.metadata ?? {}) as Record<string, unknown>,
+			spec: {} as Record<string, unknown>
+		};
+	}
 
 	$effect(() => {
-		values.spec = { ...settingsValues, ...specValues, ...resourceValues };
+		values.spec = {
+			...(settingsValues as Record<string, unknown>),
+			...(specValues as Record<string, unknown>),
+			...(resourceValues as Record<string, unknown>)
+		};
 	});
 
 	let value = $state('');
 	$effect(() => {
-		const filtered = lodash.cloneDeep(values);
-		if (filtered.metadata) {
-			for (const field of systemFields) {
-				delete filtered.metadata[field];
-			}
+		const filtered = lodash.cloneDeep(values) as typeof values & { status?: unknown };
+		for (const field of systemFields) {
+			delete filtered.metadata[field];
 		}
 		delete filtered.status;
 		value = stringify(filtered);
@@ -142,27 +173,36 @@
 				<Form
 					schema={{
 						title: 'Setting',
-						...lodash.omit(lodash.get(jsonSchema, 'properties.spec'), 'properties'),
+						...lodash.omit(lodash.get(jsonSchema, 'properties.spec') as Schema, 'properties'),
 						properties: {
 							concurrencyPolicy: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.concurrencyPolicy'),
+								...(lodash.get(
+									jsonSchema,
+									'properties.spec.properties.concurrencyPolicy'
+								) as Schema),
 								title: 'Concurrency Policy',
 								enum: ['Allow', 'Forbid', 'Replace']
 							},
 							suspend: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.suspend'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.suspend') as Schema),
 								title: 'Suspend'
 							},
 							successfulJobsHistoryLimit: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.successfulJobsHistoryLimit'),
+								...(lodash.get(
+									jsonSchema,
+									'properties.spec.properties.successfulJobsHistoryLimit'
+								) as Schema),
 								title: 'Successful Jobs History Limit'
 							},
 							failedJobsHistoryLimit: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.failedJobsHistoryLimit'),
+								...(lodash.get(
+									jsonSchema,
+									'properties.spec.properties.failedJobsHistoryLimit'
+								) as Schema),
 								title: 'Failed Jobs History Limit'
 							},
 							restartPolicy: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.restartPolicy'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.restartPolicy') as Schema),
 								title: 'Restart Policy',
 								enum: ['OnFailure', 'Never']
 							}
@@ -236,32 +276,32 @@
 					schema={{
 						title: 'Container',
 						type: 'object',
-						required: lodash
-							.get(jsonSchema, 'properties.spec.required', [])
-							.filter((f: string) => ['name', 'image', 'cronSchedule'].includes(f)),
+						required: (
+							lodash.get(jsonSchema, 'properties.spec.required', []) as string[]
+						).filter((f) => ['name', 'image', 'cronSchedule'].includes(f)),
 						properties: {
 							name: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.name'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.name') as Schema),
 								title: 'Name'
 							},
 							image: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.image'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.image') as Schema),
 								title: 'Image'
 							},
 							command: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.command'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.command') as Schema),
 								title: 'Command'
 							},
 							args: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.args'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.args') as Schema),
 								title: 'Arguments'
 							},
 							cronSchedule: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.cronSchedule'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.cronSchedule') as Schema),
 								title: 'Cron Schedule'
 							},
 							containerPort: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.containerPort'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.containerPort') as Schema),
 								title: 'Container Port'
 							}
 						}
@@ -322,27 +362,42 @@
 						type: 'object',
 						properties: {
 							resourcesRequestsCpu: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.resourcesRequestsCpu'),
+								...(lodash.get(
+									jsonSchema,
+									'properties.spec.properties.resourcesRequestsCpu'
+								) as Schema),
 								title: 'CPU Request'
 							},
 							resourcesRequestsMemory: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.resourcesRequestsMemory'),
+								...(lodash.get(
+									jsonSchema,
+									'properties.spec.properties.resourcesRequestsMemory'
+								) as Schema),
 								title: 'Memory Request'
 							},
 							resourcesLimitsCpu: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.resourcesLimitsCpu'),
+								...(lodash.get(
+									jsonSchema,
+									'properties.spec.properties.resourcesLimitsCpu'
+								) as Schema),
 								title: 'CPU Limit'
 							},
 							resourcesLimitsMemory: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.resourcesLimitsMemory'),
+								...(lodash.get(
+									jsonSchema,
+									'properties.spec.properties.resourcesLimitsMemory'
+								) as Schema),
 								title: 'Memory Limit'
 							},
 							resourcesGpu: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.resourcesGpu'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.resourcesGpu') as Schema),
 								title: 'GPU'
 							},
 							resourcesGpumem: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.resourcesGpumem'),
+								...(lodash.get(
+									jsonSchema,
+									'properties.spec.properties.resourcesGpumem'
+								) as Schema),
 								title: 'GPU Memory'
 							}
 						}

--- a/src/lib/components/kind-viewer/kind-viewer-actions/statefulset/actions.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/statefulset/actions.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import Ellipsis from '@lucide/svelte/icons/ellipsis';
+	import type { AppsV1StatefulSet } from '@otterscale/types';
+	import type { Schema } from '@sjsf/form';
 	import type { ValidateFunction } from 'ajv';
 
 	import Delete from '$lib/components/kind-viewer/kind-viewer-actions/default/delete.svelte';
@@ -24,9 +26,9 @@
 		kind,
 		resource
 	}: {
-		schema: any;
+		schema: Schema;
 		validate: ValidateFunction;
-		object: any;
+		object: AppsV1StatefulSet;
 		cluster: string;
 		namespace: string;
 		group: string;

--- a/src/lib/components/kind-viewer/kind-viewer-actions/task/actions.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/task/actions.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import Ellipsis from '@lucide/svelte/icons/ellipsis';
+	import type { Schema } from '@sjsf/form';
 
 	import Delete from '$lib/components/kind-viewer/kind-viewer-actions/default/delete.svelte';
 	import Describe from '$lib/components/kind-viewer/kind-viewer-actions/default/describe.svelte';
@@ -19,8 +20,8 @@
 		kind,
 		resource
 	}: {
-		schema: any;
-		object: any;
+		schema: Schema;
+		object: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 		cluster: string;
 		namespace: string;
 		group: string;

--- a/src/lib/components/kind-viewer/kind-viewer-actions/task/create.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/task/create.svelte
@@ -36,7 +36,7 @@
 		version: string;
 		kind: string;
 		resource: string;
-		schema?: any;
+		schema?: Schema;
 		onOpenChangeComplete: () => void;
 	} = $props();
 
@@ -47,21 +47,29 @@
 		allErrors: true,
 		strict: false
 	});
-	const validate = jsonSchemaValidator.compile(jsonSchema);
+	const validate = $derived(jsonSchemaValidator.compile(jsonSchema ?? {}));
 
 	// Container for Data — flat structure matching quickJob RGD schema
-	let values: any = $state({
-		apiVersion: group ? `${group}/${version}` : version,
-		kind,
-		metadata: {},
-		spec: {}
-	});
-	let settingsValues: any = $state({});
-	let specValues: any = $state({});
-	let resourceValues: any = $state({});
+	let values = $state(getInitialValues());
+	let settingsValues = $state<FormValue>({});
+	let specValues = $state<FormValue>({});
+	let resourceValues = $state<FormValue>({});
+
+	function getInitialValues() {
+		return {
+			apiVersion: group ? `${group}/${version}` : version,
+			kind,
+			metadata: {} as { name?: string; namespace?: string },
+			spec: {} as FormValue
+		};
+	}
 
 	$effect(() => {
-		values.spec = { ...settingsValues, ...specValues, ...resourceValues };
+		values.spec = {
+			...(settingsValues as Record<string, unknown>),
+			...(specValues as Record<string, unknown>),
+			...(resourceValues as Record<string, unknown>)
+		} as FormValue;
 	});
 
 	let value = $derived(stringify(values));
@@ -118,18 +126,18 @@
 			<Tabs.Content value={steps[0]}>
 				<Form
 					schema={{
-						...(lodash.omit(lodash.get(jsonSchema, 'properties.metadata'), 'properties') as Record<
-							string,
-							unknown
-						>),
+						...lodash.omit(
+							lodash.get(jsonSchema, 'properties.metadata') as Schema,
+							'properties'
+						),
 						title: 'Metadata',
 						properties: {
 							name: {
-								...lodash.get(jsonSchema, 'properties.metadata.properties.name'),
+								...(lodash.get(jsonSchema, 'properties.metadata.properties.name') as Schema),
 								title: 'Name'
 							},
 							namespace: {
-								...lodash.get(jsonSchema, 'properties.metadata.properties.namespace'),
+								...(lodash.get(jsonSchema, 'properties.metadata.properties.namespace') as Schema),
 								title: 'Namespace',
 								readOnly: true
 							}
@@ -171,34 +179,40 @@
 				<Form
 					schema={{
 						title: 'Setting',
-						...lodash.omit(lodash.get(jsonSchema, 'properties.spec'), 'properties'),
+						...lodash.omit(lodash.get(jsonSchema, 'properties.spec') as Schema, 'properties'),
 						properties: {
 							completions: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.completions'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.completions') as Schema),
 								title: 'Completions'
 							},
 							parallelism: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.parallelism'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.parallelism') as Schema),
 								title: 'Parallelism'
 							},
 							backoffLimit: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.backoffLimit'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.backoffLimit') as Schema),
 								title: 'Backoff Limit'
 							},
 							activeDeadlineSeconds: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.activeDeadlineSeconds'),
+								...(lodash.get(
+									jsonSchema,
+									'properties.spec.properties.activeDeadlineSeconds'
+								) as Schema),
 								title: 'Active Deadline Seconds'
 							},
 							ttlSecondsAfterFinished: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.ttlSecondsAfterFinished'),
+								...(lodash.get(
+									jsonSchema,
+									'properties.spec.properties.ttlSecondsAfterFinished'
+								) as Schema),
 								title: 'TTL Seconds After Finished'
 							},
 							suspend: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.suspend'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.suspend') as Schema),
 								title: 'Suspend'
 							},
 							restartPolicy: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.restartPolicy'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.restartPolicy') as Schema),
 								title: 'Restart Policy',
 								enum: ['Never', 'OnFailure']
 							}
@@ -268,28 +282,28 @@
 					schema={{
 						title: 'Container',
 						type: 'object',
-						required: lodash
-							.get(jsonSchema, 'properties.spec.required', [])
-							.filter((f: string) => ['name', 'image'].includes(f)),
+						required: (
+							lodash.get(jsonSchema, 'properties.spec.required', []) as string[]
+						).filter((f) => ['name', 'image'].includes(f)),
 						properties: {
 							name: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.name'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.name') as Schema),
 								title: 'Name'
 							},
 							image: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.image'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.image') as Schema),
 								title: 'Image'
 							},
 							command: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.command'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.command') as Schema),
 								title: 'Command'
 							},
 							args: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.args'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.args') as Schema),
 								title: 'Arguments'
 							},
 							containerPort: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.containerPort'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.containerPort') as Schema),
 								title: 'Container Port'
 							}
 						}
@@ -312,7 +326,7 @@
 						}
 					} as UiSchemaRoot}
 					initialValue={{
-						name: values.metadata?.name ?? null,
+						name: values.metadata.name ?? null,
 						image: null,
 						containerPort: 8080
 					} as FormValue}
@@ -346,27 +360,42 @@
 						type: 'object',
 						properties: {
 							resourcesRequestsCpu: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.resourcesRequestsCpu'),
+								...(lodash.get(
+									jsonSchema,
+									'properties.spec.properties.resourcesRequestsCpu'
+								) as Schema),
 								title: 'CPU Request'
 							},
 							resourcesRequestsMemory: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.resourcesRequestsMemory'),
+								...(lodash.get(
+									jsonSchema,
+									'properties.spec.properties.resourcesRequestsMemory'
+								) as Schema),
 								title: 'Memory Request'
 							},
 							resourcesLimitsCpu: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.resourcesLimitsCpu'),
+								...(lodash.get(
+									jsonSchema,
+									'properties.spec.properties.resourcesLimitsCpu'
+								) as Schema),
 								title: 'CPU Limit'
 							},
 							resourcesLimitsMemory: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.resourcesLimitsMemory'),
+								...(lodash.get(
+									jsonSchema,
+									'properties.spec.properties.resourcesLimitsMemory'
+								) as Schema),
 								title: 'Memory Limit'
 							},
 							resourcesGpu: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.resourcesGpu'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.resourcesGpu') as Schema),
 								title: 'GPU'
 							},
 							resourcesGpumem: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.resourcesGpumem'),
+								...(lodash.get(
+									jsonSchema,
+									'properties.spec.properties.resourcesGpumem'
+								) as Schema),
 								title: 'GPU Memory'
 							}
 						}
@@ -436,7 +465,7 @@
 
 							isSubmitting = true;
 
-							let parsed: any;
+							let parsed: unknown;
 							try {
 								parsed = load(value);
 							} catch {

--- a/src/lib/components/kind-viewer/kind-viewer-actions/task/create.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/task/create.svelte
@@ -126,10 +126,7 @@
 			<Tabs.Content value={steps[0]}>
 				<Form
 					schema={{
-						...lodash.omit(
-							lodash.get(jsonSchema, 'properties.metadata') as Schema,
-							'properties'
-						),
+						...lodash.omit(lodash.get(jsonSchema, 'properties.metadata') as Schema, 'properties'),
 						title: 'Metadata',
 						properties: {
 							name: {
@@ -282,9 +279,9 @@
 					schema={{
 						title: 'Container',
 						type: 'object',
-						required: (
-							lodash.get(jsonSchema, 'properties.spec.required', []) as string[]
-						).filter((f) => ['name', 'image'].includes(f)),
+						required: (lodash.get(jsonSchema, 'properties.spec.required', []) as string[]).filter(
+							(f) => ['name', 'image'].includes(f)
+						),
 						properties: {
 							name: {
 								...(lodash.get(jsonSchema, 'properties.spec.properties.name') as Schema),
@@ -392,10 +389,7 @@
 								title: 'GPU'
 							},
 							resourcesGpumem: {
-								...(lodash.get(
-									jsonSchema,
-									'properties.spec.properties.resourcesGpumem'
-								) as Schema),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.resourcesGpumem') as Schema),
 								title: 'GPU Memory'
 							}
 						}

--- a/src/lib/components/kind-viewer/kind-viewer-actions/task/update.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/task/update.svelte
@@ -35,10 +35,36 @@
 		version: string;
 		kind: string;
 		resource: string;
-		schema: any;
-		object: any;
+		schema: Schema;
+		object: TaskObject;
 		onOpenChangeComplete: () => void;
 	} = $props();
+
+	type TaskSpec = {
+		name?: string;
+		image?: string;
+		command?: string[];
+		args?: string[];
+		containerPort?: number;
+		completions?: number;
+		parallelism?: number;
+		backoffLimit?: number;
+		activeDeadlineSeconds?: number;
+		ttlSecondsAfterFinished?: number;
+		suspend?: boolean;
+		restartPolicy?: string;
+		resourcesRequestsCpu?: string;
+		resourcesRequestsMemory?: string;
+		resourcesLimitsCpu?: string;
+		resourcesLimitsMemory?: string;
+		resourcesGpu?: string;
+		resourcesGpumem?: string;
+	};
+
+	type TaskObject = {
+		metadata?: { name?: string; namespace?: string; [k: string]: unknown };
+		spec?: TaskSpec;
+	};
 
 	const transport: Transport = getContext('transport');
 	const resourceClient = createClient(ResourceService, transport);
@@ -61,27 +87,33 @@
 		'uid'
 	];
 
-	let values: any = $state({
-		apiVersion: group ? `${group}/${version}` : version,
-		kind,
-		metadata: object.metadata,
-		spec: {}
-	});
-	let settingsValues: any = $state({});
-	let specValues: any = $state({});
-	let resourceValues: any = $state({});
+	let values = $state(getInitialValues());
+	let settingsValues = $state<FormValue>({});
+	let specValues = $state<FormValue>({});
+	let resourceValues = $state<FormValue>({});
+
+	function getInitialValues() {
+		return {
+			apiVersion: group ? `${group}/${version}` : version,
+			kind,
+			metadata: (object.metadata ?? {}) as Record<string, unknown>,
+			spec: {} as Record<string, unknown>
+		};
+	}
 
 	$effect(() => {
-		values.spec = { ...settingsValues, ...specValues, ...resourceValues };
+		values.spec = {
+			...(settingsValues as Record<string, unknown>),
+			...(specValues as Record<string, unknown>),
+			...(resourceValues as Record<string, unknown>)
+		};
 	});
 
 	let value = $state('');
 	$effect(() => {
-		const filtered = lodash.cloneDeep(values);
-		if (filtered.metadata) {
-			for (const field of systemFields) {
-				delete filtered.metadata[field];
-			}
+		const filtered = lodash.cloneDeep(values) as typeof values & { status?: unknown };
+		for (const field of systemFields) {
+			delete filtered.metadata[field];
 		}
 		delete filtered.status;
 		value = stringify(filtered);
@@ -142,34 +174,40 @@
 				<Form
 					schema={{
 						title: 'Setting',
-						...lodash.omit(lodash.get(jsonSchema, 'properties.spec'), 'properties'),
+						...lodash.omit(lodash.get(jsonSchema, 'properties.spec') as Schema, 'properties'),
 						properties: {
 							completions: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.completions'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.completions') as Schema),
 								title: 'Completions'
 							},
 							parallelism: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.parallelism'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.parallelism') as Schema),
 								title: 'Parallelism'
 							},
 							backoffLimit: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.backoffLimit'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.backoffLimit') as Schema),
 								title: 'Backoff Limit'
 							},
 							activeDeadlineSeconds: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.activeDeadlineSeconds'),
+								...(lodash.get(
+									jsonSchema,
+									'properties.spec.properties.activeDeadlineSeconds'
+								) as Schema),
 								title: 'Active Deadline Seconds'
 							},
 							ttlSecondsAfterFinished: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.ttlSecondsAfterFinished'),
+								...(lodash.get(
+									jsonSchema,
+									'properties.spec.properties.ttlSecondsAfterFinished'
+								) as Schema),
 								title: 'TTL Seconds After Finished'
 							},
 							suspend: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.suspend'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.suspend') as Schema),
 								title: 'Suspend'
 							},
 							restartPolicy: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.restartPolicy'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.restartPolicy') as Schema),
 								title: 'Restart Policy',
 								enum: ['Never', 'OnFailure']
 							}
@@ -240,28 +278,28 @@
 					schema={{
 						title: 'Container',
 						type: 'object',
-						required: lodash
-							.get(jsonSchema, 'properties.spec.required', [])
-							.filter((f: string) => ['name', 'image'].includes(f)),
+						required: (
+							lodash.get(jsonSchema, 'properties.spec.required', []) as string[]
+						).filter((f) => ['name', 'image'].includes(f)),
 						properties: {
 							name: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.name'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.name') as Schema),
 								title: 'Name'
 							},
 							image: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.image'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.image') as Schema),
 								title: 'Image'
 							},
 							command: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.command'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.command') as Schema),
 								title: 'Command'
 							},
 							args: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.args'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.args') as Schema),
 								title: 'Arguments'
 							},
 							containerPort: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.containerPort'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.containerPort') as Schema),
 								title: 'Container Port'
 							}
 						}
@@ -321,27 +359,42 @@
 						type: 'object',
 						properties: {
 							resourcesRequestsCpu: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.resourcesRequestsCpu'),
+								...(lodash.get(
+									jsonSchema,
+									'properties.spec.properties.resourcesRequestsCpu'
+								) as Schema),
 								title: 'CPU Request'
 							},
 							resourcesRequestsMemory: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.resourcesRequestsMemory'),
+								...(lodash.get(
+									jsonSchema,
+									'properties.spec.properties.resourcesRequestsMemory'
+								) as Schema),
 								title: 'Memory Request'
 							},
 							resourcesLimitsCpu: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.resourcesLimitsCpu'),
+								...(lodash.get(
+									jsonSchema,
+									'properties.spec.properties.resourcesLimitsCpu'
+								) as Schema),
 								title: 'CPU Limit'
 							},
 							resourcesLimitsMemory: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.resourcesLimitsMemory'),
+								...(lodash.get(
+									jsonSchema,
+									'properties.spec.properties.resourcesLimitsMemory'
+								) as Schema),
 								title: 'Memory Limit'
 							},
 							resourcesGpu: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.resourcesGpu'),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.resourcesGpu') as Schema),
 								title: 'GPU'
 							},
 							resourcesGpumem: {
-								...lodash.get(jsonSchema, 'properties.spec.properties.resourcesGpumem'),
+								...(lodash.get(
+									jsonSchema,
+									'properties.spec.properties.resourcesGpumem'
+								) as Schema),
 								title: 'GPU Memory'
 							}
 						}

--- a/src/lib/components/kind-viewer/kind-viewer-actions/task/update.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/task/update.svelte
@@ -278,9 +278,9 @@
 					schema={{
 						title: 'Container',
 						type: 'object',
-						required: (
-							lodash.get(jsonSchema, 'properties.spec.required', []) as string[]
-						).filter((f) => ['name', 'image'].includes(f)),
+						required: (lodash.get(jsonSchema, 'properties.spec.required', []) as string[]).filter(
+							(f) => ['name', 'image'].includes(f)
+						),
 						properties: {
 							name: {
 								...(lodash.get(jsonSchema, 'properties.spec.properties.name') as Schema),
@@ -391,10 +391,7 @@
 								title: 'GPU'
 							},
 							resourcesGpumem: {
-								...(lodash.get(
-									jsonSchema,
-									'properties.spec.properties.resourcesGpumem'
-								) as Schema),
+								...(lodash.get(jsonSchema, 'properties.spec.properties.resourcesGpumem') as Schema),
 								title: 'GPU Memory'
 							}
 						}

--- a/src/lib/components/kind-viewer/kind-viewer-actions/virtual-machine-service/vm-service-ports-cell.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/virtual-machine-service/vm-service-ports-cell.svelte
@@ -9,6 +9,7 @@
 	import ChevronRight from '@lucide/svelte/icons/chevron-right';
 	import File from '@lucide/svelte/icons/file';
 	import { ResourceService, type SchemaRequest } from '@otterscale/api/resource/v1';
+	import type { CoreV1Service } from '@otterscale/types';
 	import type { Schema } from '@sjsf/form';
 	import {
 		type ColumnDef,
@@ -51,7 +52,7 @@
 	const resourceClient = createClient(ResourceService, transport);
 
 	// Service data
-	let service: any = $state(null);
+	let service: CoreV1Service | null = $state(null);
 	let servicePorts: ArrayOfObjectItemsType = $state([]);
 	let portsCount = $derived(servicePorts.length);
 
@@ -87,9 +88,9 @@
 			const matchedService = response.items[0] ?? null;
 
 			if (matchedService) {
-				service = matchedService.object;
-				const ports = (service as any)?.spec?.ports ?? [];
-				servicePorts = ports.map((p: any) => ({
+				service = matchedService.object as CoreV1Service;
+				const ports = service.spec?.ports ?? [];
+				servicePorts = ports.map((p) => ({
 					title: p.name ?? `${p.port}`,
 					description: `${p.port}${p.nodePort ? `:${p.nodePort}` : ''}/${p.protocol ?? 'TCP'}`,
 					raw: p as JsonObject


### PR DESCRIPTION
Replace any with concrete schema/resource types across action components (cluster-role-binding, cronjob, daemonset, data-volume, deployment, instance-type, job, pod, resource-quota, schedule, statefulset, task, virtual-machine-service).

Also hide the 'upload' source type in data-volume create/update — no upload UI exists yet to handle the post-create data transfer.