### PR TITLE
fix: resolve any-type and state-referenced-locally warnings

### DIFF
--- a/src/lib/components/dashboard/compute/index.svelte
+++ b/src/lib/components/dashboard/compute/index.svelte
@@ -35,9 +35,11 @@
 	} = $props();
 
 	/** Currently selected namespace; empty string means "all namespaces" */
-	let selectedNamespace = $state<string | undefined>(
-		defaultNamespace !== '' ? defaultNamespace : undefined
-	);
+	let selectedNamespace = $state<string | undefined>(getInitialNamespace());
+
+	function getInitialNamespace() {
+		return defaultNamespace !== '' ? defaultNamespace : undefined;
+	}
 	let selectedTab = $state('overview');
 	let selectedVM = $state<string | undefined>(undefined);
 

--- a/src/lib/components/dashboard/model/index.svelte
+++ b/src/lib/components/dashboard/model/index.svelte
@@ -37,9 +37,11 @@
 	let prometheusDriver = $state<PrometheusDriver | null>(null);
 	let selectedTab = $state('overview');
 	/** Currently selected namespace; empty string means "all namespaces" */
-	let selectedNamespace = $state<string | undefined>(
-		defaultNamespace !== '' ? defaultNamespace : undefined
-	);
+	let selectedNamespace = $state<string | undefined>(getInitialNamespace());
+
+	function getInitialNamespace() {
+		return defaultNamespace !== '' ? defaultNamespace : undefined;
+	}
 	/** vLLM analytics model filter; lives next to NamespacePicker so chart grid does not shift vertically */
 	let selectedModel = $state<string | undefined>(undefined);
 

--- a/src/lib/components/dashboard/workspace/overview/workload-health.svelte
+++ b/src/lib/components/dashboard/workspace/overview/workload-health.svelte
@@ -43,9 +43,6 @@
 		isReloading: boolean;
 	} = $props();
 
-	// widget-grid passes prometheusDriver to every tile; this widget uses Resource API only.
-	void prometheusDriver;
-
 	const transport: Transport = getContext('transport');
 	const resourceClient = createClient(ResourceService, transport);
 
@@ -156,6 +153,8 @@
 
 	let isLoaded = $state(false);
 	onMount(async () => {
+		// widget-grid passes prometheusDriver to every tile; this widget uses Resource API only.
+		void prometheusDriver;
 		await fetch();
 		isLoaded = true;
 	});

--- a/src/lib/components/dynamic-form/form.svelte
+++ b/src/lib/components/dynamic-form/form.svelte
@@ -158,9 +158,7 @@
 		extraUiOptions,
 		schema,
 		uiSchema,
-		get initialValue() {
-			return initialValue;
-		},
+		initialValue,
 		validator,
 		onSubmit,
 		onSubmitError

--- a/src/lib/components/kind-viewer/kind-viewer-actions/default/create.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/default/create.svelte
@@ -266,7 +266,10 @@
 				</Item.Root>
 			</Dialog.Header>
 			<div class="grid grid-cols-2 gap-4 *:max-h-[62vh] *:min-h-[62vh]">
-				<SchemaViewer schema={jsonSchema} class="h-full max-h-screen min-h-0 overflow-auto" />
+				<SchemaViewer
+					schema={jsonSchema as object}
+					class="h-full max-h-screen min-h-0 overflow-auto"
+				/>
 				<div class="transition-opacity duration-300 {isReady ? 'opacity-100' : 'opacity-0'}">
 					<Monaco
 						options={{

--- a/src/lib/components/kind-viewer/kind-viewer-actions/helm-release/actions.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/helm-release/actions.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import Ellipsis from '@lucide/svelte/icons/ellipsis';
+	import type { HelmToolkitFluxcdIoV2HelmRelease } from '@otterscale/types';
+	import type { Schema } from '@sjsf/form';
 	import type { ValidateFunction } from 'ajv';
 
 	import Delete from '$lib/components/kind-viewer/kind-viewer-actions/default/delete.svelte';
@@ -22,9 +24,9 @@
 		kind,
 		resource
 	}: {
-		schema: any;
+		schema: Schema;
 		validate: ValidateFunction;
-		object: any;
+		object: HelmToolkitFluxcdIoV2HelmRelease;
 		cluster: string;
 		namespace: string;
 		group: string;

--- a/src/lib/components/kind-viewer/kind-viewer-actions/helm-repository/actions.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/helm-repository/actions.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import Ellipsis from '@lucide/svelte/icons/ellipsis';
+	import type { SourceToolkitFluxcdIoV1HelmRepository } from '@otterscale/types';
+	import type { Schema } from '@sjsf/form';
 	import type { ValidateFunction } from 'ajv';
 
 	import Delete from '$lib/components/kind-viewer/kind-viewer-actions/default/delete.svelte';
@@ -22,9 +24,9 @@
 		kind,
 		resource
 	}: {
-		schema: any;
+		schema: Schema;
 		validate: ValidateFunction;
-		object: any;
+		object: SourceToolkitFluxcdIoV1HelmRepository;
 		cluster: string;
 		namespace: string;
 		group: string;

--- a/src/lib/components/kind-viewer/kind-viewer-actions/index.ts
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/index.ts
@@ -1,4 +1,6 @@
+import type { JsonObject, JsonValue } from '@bufbuild/protobuf';
 import type { Schema } from '@sjsf/form';
+import type { Row } from '@tanstack/table-core';
 import { type ValidateFunction } from 'ajv';
 import type { Component } from 'svelte';
 
@@ -51,10 +53,10 @@ type CreateType = Component<{
 }> | null;
 type ActionsType = Component<{
 	role?: string;
-	row?: any;
+	row?: Row<Record<string, JsonValue>>;
 	schema?: Schema;
 	validate?: ValidateFunction;
-	object?: any;
+	object?: JsonObject;
 	cluster?: string;
 	namespace?: string;
 	group?: string;

--- a/src/lib/components/kind-viewer/kind-viewer-actions/llm-inference-service/create.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/llm-inference-service/create.svelte
@@ -36,21 +36,25 @@
 		version: string;
 		kind: string;
 		resource: string;
-		schema: any;
+		schema: Schema;
 	} = $props();
 
 	const transport: Transport = getContext('transport');
 	const resourceClient = createClient(ResourceService, transport);
 
 	// Container for Data
-	let values: any = $state({
-		apiVersion: `${group}/${version}`,
-		kind,
-		metadata: {},
-		spec: {
-			baseRefs: []
-		}
-	});
+	let values = $state(getInitialValues());
+
+	function getInitialValues() {
+		return {
+			apiVersion: `${group}/${version}`,
+			kind,
+			metadata: {} as FormValue,
+			spec: {
+				baseRefs: [] as { name: string }[]
+			}
+		};
+	}
 	let value = $derived(stringify(values));
 
 	// ===== Faceted GPU selector =====
@@ -119,11 +123,11 @@
 			<Tabs.Content value={steps[0]}>
 				<Form
 					schema={{
-						...(lodash.omit(lodash.get(jsonSchema, 'properties.metadata'), 'properties') as any),
+						...lodash.omit(lodash.get(jsonSchema, 'properties.metadata') as Schema, 'properties'),
 						title: 'Metadata',
 						properties: {
 							name: {
-								...lodash.get(jsonSchema, 'properties.metadata.properties.name'),
+								...(lodash.get(jsonSchema, 'properties.metadata.properties.name') as Schema),
 								title: 'Name'
 							}
 						}
@@ -165,7 +169,7 @@
 				{#await resourceClient.list( { cluster, namespace, group: 'serving.kserve.io', version: 'v1alpha2', resource: 'llminferenceserviceconfigs' } )}
 					Loading
 				{:then response}
-					{@const templateNames = response.items.map((item: any) =>
+					{@const templateNames = response.items.map((item) =>
 						lodash.get(item.object, 'metadata.name')
 					)}
 					<Form

--- a/src/lib/components/kind-viewer/kind-viewer-actions/llm-inference-service/update.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/llm-inference-service/update.svelte
@@ -2,7 +2,8 @@
 	import { ConnectError, createClient, type Transport } from '@connectrpc/connect';
 	import FormIcon from '@lucide/svelte/icons/form';
 	import { ResourceService } from '@otterscale/api/resource/v1';
-	import type { FormValue, UiSchemaRoot } from '@sjsf/form';
+	import type { ServingKserveIoV1Alpha1LLMInferenceService } from '@otterscale/types';
+	import type { FormValue, Schema, UiSchemaRoot } from '@sjsf/form';
 	import { getValueSnapshot, SubmitButton } from '@sjsf/form';
 	import Ajv from 'ajv';
 	import { load } from 'js-yaml';
@@ -38,8 +39,8 @@
 		version: string;
 		kind: string;
 		resource: string;
-		schema: any;
-		object: any;
+		schema: Schema;
+		object: ServingKserveIoV1Alpha1LLMInferenceService;
 		onOpenChangeComplete: () => void;
 	} = $props();
 
@@ -47,7 +48,13 @@
 	const resourceClient = createClient(ResourceService, transport);
 
 	// Container for Data – initialised from the existing object
-	let values: any = $state(lodash.cloneDeep(object));
+	let values = $state(getInitialValues());
+
+	function getInitialValues() {
+		return lodash.cloneDeep(object) as ServingKserveIoV1Alpha1LLMInferenceService & {
+			metadata?: Record<string, unknown>;
+		};
+	}
 
 	const systemFields = [
 		'clusterName',

--- a/src/lib/components/kind-viewer/kind-viewer-actions/workspace/actions.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/workspace/actions.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import Ellipsis from '@lucide/svelte/icons/ellipsis';
 	import type { TenantOtterscaleIoV1Alpha1Workspace } from '@otterscale/types';
+	import type { Schema } from '@sjsf/form';
 
 	import Delete from '$lib/components/kind-viewer/kind-viewer-actions/default/delete.svelte';
 	import Describe from '$lib/components/kind-viewer/kind-viewer-actions/default/describe.svelte';
@@ -21,7 +22,7 @@
 		resource
 	}: {
 		role?: string;
-		schema: any;
+		schema: Schema;
 		object: TenantOtterscaleIoV1Alpha1Workspace;
 		cluster: string;
 		group: string;

--- a/src/lib/components/kind-viewer/kind-viewer.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { type JsonValue } from '@bufbuild/protobuf';
+	import type { JsonObject, JsonValue } from '@bufbuild/protobuf';
 	import { createClient, type Transport } from '@connectrpc/connect';
 	import { EllipsisIcon } from '@lucide/svelte';
 	import BanIcon from '@lucide/svelte/icons/ban';
@@ -114,7 +114,7 @@
 				resourceVersion = response.resourceVersion;
 				continueToken = response.continue;
 
-				const newData = response.items.map((item) => getData(apiResource, item.object));
+				const newData = response.items.map((item) => getData(apiResource, item.object ?? {}));
 				dataset = [...dataset, ...newData];
 
 				isMounted = true;
@@ -369,7 +369,7 @@
 					<Actions
 						role={isClusterAdmin ? 'Cluster Admin' : undefined}
 						{row}
-						object={row.original.raw}
+						object={row.original.raw as JsonObject | undefined}
 						{schema}
 						{validate}
 						{cluster}

--- a/src/lib/components/kind-viewer/kind-viewers/application.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/application.ts
@@ -33,9 +33,19 @@ function getApplicationDataSchemas(): Record<ApplicationAttribute, DataSchemaTyp
 	};
 }
 
-function getApplicationData(object: any): Record<ApplicationAttribute, JsonValue> {
+type ApplicationObject = {
+	metadata?: { name?: string; namespace?: string; creationTimestamp?: string };
+	spec?: { serviceType?: string };
+	status?: {
+		state?: string;
+		nodePort?: number | string;
+		conditions?: { type?: string; status?: string }[];
+	};
+};
+
+function getApplicationData(object: ApplicationObject): Record<ApplicationAttribute, JsonValue> {
 	const readyCondition = object?.status?.conditions?.find(
-		(condition: any) => condition.type === 'Ready'
+		(condition) => condition.type === 'Ready'
 	);
 
 	return {

--- a/src/lib/components/kind-viewer/kind-viewers/ceph-object-bucket-claim.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/ceph-object-bucket-claim.ts
@@ -1,5 +1,6 @@
 import { type JsonObject, type JsonValue } from '@bufbuild/protobuf';
 import type { APIResource } from '@otterscale/api/resource/v1';
+import type { ObjectbucketIoV1Alpha1ObjectBucketClaim } from '@otterscale/types';
 import type { Column, ColumnDef } from '@tanstack/table-core';
 import { type Row } from '@tanstack/table-core';
 
@@ -35,15 +36,17 @@ function getObjectBucketClaimDataSchemas(): Record<ObjectBucketClaimAttribute, D
 	};
 }
 
-function getObjectBucketClaimData(object: any): Record<ObjectBucketClaimAttribute, JsonValue> {
+function getObjectBucketClaimData(
+	object: ObjectbucketIoV1Alpha1ObjectBucketClaim
+): Record<ObjectBucketClaimAttribute, JsonValue> {
 	return {
 		Name: object?.metadata?.name ?? null,
 		Namespace: object?.metadata?.namespace ?? null,
 		'Storage Class': object?.spec?.storageClassName ?? null,
 		'Bucket Name': object?.spec?.bucketName ?? null,
-		'Bucket Owner': object?.spec?.additionalConfig?.bucketOwner ?? null,
-		'Bucket Policy': object?.spec?.additionalConfig?.bucketPolicy ?? null,
-		Phase: object?.status?.phase ?? null,
+		'Bucket Owner': (object?.spec?.additionalConfig?.bucketOwner as string | undefined) ?? null,
+		'Bucket Policy': (object?.spec?.additionalConfig?.bucketPolicy as string | undefined) ?? null,
+		Phase: (object?.status?.phase as string | undefined) ?? null,
 		Age: object?.metadata?.creationTimestamp ?? null,
 		raw: (object as JsonObject) ?? null
 	};

--- a/src/lib/components/kind-viewer/kind-viewers/datavolume.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/datavolume.ts
@@ -1,5 +1,6 @@
 import { type JsonObject, type JsonValue } from '@bufbuild/protobuf';
 import type { APIResource } from '@otterscale/api/resource/v1';
+import type { CdiKubevirtIoV1Beta1DataVolume } from '@otterscale/types';
 import type { Column, ColumnDef } from '@tanstack/table-core';
 import { type Row } from '@tanstack/table-core';
 
@@ -37,40 +38,48 @@ function getDataVolumeDataSchemas(): Record<DataVolumeAttribute, DataSchemaType>
 	};
 }
 
-function getDataVolumeData(object: any): Record<DataVolumeAttribute, JsonValue> {
-	// Determine source type from spec.source
+type LegacyStorageSpec = {
+	storage?: {
+		resources?: { requests?: { storage?: string | number } };
+		accessModes?: string[];
+	};
+};
+
+function getDataVolumeData(
+	object: CdiKubevirtIoV1Beta1DataVolume
+): Record<DataVolumeAttribute, JsonValue> {
+	// Determine source type from spec.source (variants are mutually exclusive per CDI CRD)
 	const source = object?.spec?.source;
 	let sourceDisplay: string | null = null;
 	if (source) {
-		const sourceType = Object.keys(source).find(
-			(k) => source[k] && Object.keys(source[k]).length >= 0
-		);
-		if (sourceType) {
-			const details = source[sourceType];
-			if (sourceType === 'http' || sourceType === 's3' || sourceType === 'gcs') {
-				sourceDisplay = `${sourceType}: ${details?.url ?? ''}`;
-			} else if (sourceType === 'registry') {
-				sourceDisplay = `registry: ${details?.url ?? details?.imageStream ?? ''}`;
-			} else if (sourceType === 'pvc') {
-				sourceDisplay = `pvc: ${details?.namespace ?? ''}/${details?.name ?? ''}`;
-			} else if (sourceType === 'snapshot') {
-				sourceDisplay = `snapshot: ${details?.namespace ?? ''}/${details?.name ?? ''}`;
-			} else {
-				sourceDisplay = sourceType;
-			}
+		if (source.http) sourceDisplay = `http: ${source.http.url ?? ''}`;
+		else if (source.s3) sourceDisplay = `s3: ${source.s3.url ?? ''}`;
+		else if (source.gcs) sourceDisplay = `gcs: ${source.gcs.url ?? ''}`;
+		else if (source.registry)
+			sourceDisplay = `registry: ${source.registry.url ?? source.registry.imageStream ?? ''}`;
+		else if (source.pvc)
+			sourceDisplay = `pvc: ${source.pvc.namespace ?? ''}/${source.pvc.name ?? ''}`;
+		else if (source.snapshot)
+			sourceDisplay = `snapshot: ${source.snapshot.namespace ?? ''}/${source.snapshot.name ?? ''}`;
+		else {
+			const [first] = Object.keys(source);
+			if (first) sourceDisplay = first;
 		}
 	} else if (object?.spec?.sourceRef) {
 		sourceDisplay = `ref: ${object.spec.sourceRef.kind}/${object.spec.sourceRef.name}`;
 	}
 
-	// Storage size from spec.pvc or spec.storage
+	// Storage size from spec.pvc or legacy spec.storage
 	const storage =
 		object?.spec?.pvc?.resources?.requests?.storage ??
-		object?.spec?.storage?.resources?.requests?.storage ??
+		(object?.spec as LegacyStorageSpec | undefined)?.storage?.resources?.requests?.storage ??
 		null;
 
-	// Access modes from spec.pvc or spec.storage
-	const accessModes = object?.spec?.pvc?.accessModes ?? object?.spec?.storage?.accessModes ?? null;
+	// Access modes from spec.pvc or legacy spec.storage
+	const accessModes =
+		object?.spec?.pvc?.accessModes ??
+		(object?.spec as LegacyStorageSpec | undefined)?.storage?.accessModes ??
+		null;
 	const accessModesDisplay = Array.isArray(accessModes) ? accessModes.join(', ') : null;
 
 	return {

--- a/src/lib/components/kind-viewer/kind-viewers/default.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/default.ts
@@ -1,4 +1,4 @@
-import { type JsonValue } from '@bufbuild/protobuf';
+import { type JsonObject, type JsonValue } from '@bufbuild/protobuf';
 import type { APIResource } from '@otterscale/api/resource/v1';
 import type { Column, ColumnDef } from '@tanstack/table-core';
 import { type Row } from '@tanstack/table-core';
@@ -31,9 +31,19 @@ function getDefaultDataSchemas(): Record<DefaultAttribute, DataSchemaType> {
 	};
 }
 
+type DefaultObject = {
+	metadata?: {
+		name?: string;
+		namespace?: string;
+		labels?: Record<string, string>;
+		annotations?: Record<string, string>;
+		creationTimestamp?: string;
+	};
+} & JsonObject;
+
 function getDefaultData(
 	apiResource: APIResource,
-	object: any
+	object: DefaultObject
 ): Record<DefaultAttribute, JsonValue> {
 	return {
 		Name: object?.metadata?.name ?? null,
@@ -132,8 +142,8 @@ function getDefaultColumnDefinitions(
 					row: row,
 					column: column,
 					uiSchemas: uiSchemas,
-					metadata: ((row.original.raw as any).metadata.annotations ??
-						{}) satisfies ObjectOfKeyValueMetadata
+					metadata: ((row.original.raw as { metadata?: { annotations?: Record<string, string> } })
+						?.metadata?.annotations ?? {}) satisfies ObjectOfKeyValueMetadata
 				}),
 			accessorFn: (row: Record<DefaultAttribute, JsonValue>) =>
 				row['Annotations'] ? Object.keys(row['Annotations'] as object).length : null
@@ -156,8 +166,8 @@ function getDefaultColumnDefinitions(
 					row: row,
 					column: column,
 					uiSchemas: uiSchemas,
-					metadata: ((row.original.raw as any).metadata.labels ??
-						{}) satisfies ObjectOfKeyValueMetadata
+					metadata: ((row.original.raw as { metadata?: { labels?: Record<string, string> } })
+						?.metadata?.labels ?? {}) satisfies ObjectOfKeyValueMetadata
 				}),
 			accessorFn: (row: Record<DefaultAttribute, JsonValue>) =>
 				row['Labels'] ? Object.keys(row['Labels'] as object).length : null

--- a/src/lib/components/kind-viewer/kind-viewers/index.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/index.ts
@@ -1,4 +1,4 @@
-import type { JsonValue } from '@bufbuild/protobuf';
+import type { JsonObject, JsonValue } from '@bufbuild/protobuf';
 import type { APIResource } from '@otterscale/api/resource/v1';
 import type { ColumnDef } from '@tanstack/table-core';
 
@@ -312,86 +312,89 @@ function getDataSchemas(kind: string): Record<string, DataSchemaType> {
 	}
 }
 
-function getData(apiResource: APIResource, object: any): Record<string, JsonValue> {
+function getData(apiResource: APIResource, object: JsonObject): Record<string, JsonValue> {
+	// Each Kind handler accepts its own specific K8s type; cast through `never` to satisfy
+	// all of those signatures in a single dispatch without per-case casts.
+	const o = object as never;
 	switch (apiResource.kind) {
 		case 'CronJob':
-			return getCronJobData(object);
+			return getCronJobData(o);
 		case 'DaemonSet':
-			return getDaemonSetData(object);
+			return getDaemonSetData(o);
 		case 'Deployment':
-			return getDeploymentData(object);
+			return getDeploymentData(o);
 		case 'Job':
-			return getJobData(object);
+			return getJobData(o);
 		case 'Pod':
-			return getPodData(object);
+			return getPodData(o);
 		case 'StatefulSet':
-			return getStatefulSetData(object);
+			return getStatefulSetData(o);
 		case 'ConfigMap':
-			return getConfigMapData(object);
+			return getConfigMapData(o);
 		case 'Secret':
-			return getSecretData(object);
+			return getSecretData(o);
 		case 'Service':
-			return getServiceData(object);
+			return getServiceData(o);
 		case 'NetworkPolicy':
-			return getNetworkPolicyData(object);
+			return getNetworkPolicyData(o);
 		case 'PersistentVolumeClaim':
-			return getPVCData(object);
+			return getPVCData(o);
 		case 'PersistentVolume':
-			return getPVData(object);
+			return getPVData(o);
 		case 'StorageClass':
-			return getStorageClassData(object);
+			return getStorageClassData(o);
 		case 'Namespace':
-			return getNamespaceData(object);
+			return getNamespaceData(o);
 		case 'ServiceAccount':
-			return getServiceAccountData(object);
+			return getServiceAccountData(o);
 		case 'Role':
-			return getRoleData(object);
+			return getRoleData(o);
 		case 'RoleBinding':
-			return getRoleBindingData(object);
+			return getRoleBindingData(o);
 		case 'ClusterRole':
-			return getClusterRoleData(object);
+			return getClusterRoleData(o);
 		case 'ClusterRoleBinding':
-			return getClusterRoleBindingData(object);
+			return getClusterRoleBindingData(o);
 		case 'LimitRange':
-			return getLimitRangeData(object);
+			return getLimitRangeData(o);
 		case 'Event':
-			return getEventData(object);
+			return getEventData(o);
 		case 'Node':
-			return getNodeData(object);
+			return getNodeData(o);
 		case 'CustomResourceDefinition':
-			return getCRDData(object);
+			return getCRDData(o);
 		case 'ResourceQuota':
-			return getResourceQuotaData(object);
+			return getResourceQuotaData(o);
 		case 'Workspace':
-			return getWorkspaceData(object);
+			return getWorkspaceData(o);
 		case 'HelmRepository':
-			return getHelmRepositoryData(object);
+			return getHelmRepositoryData(o);
 		case 'HTTPRoute':
-			return getHTTPRouteData(object);
+			return getHTTPRouteData(o);
 		case 'Gateway':
-			return getGatewayData(object);
+			return getGatewayData(o);
 		case 'HelmRelease':
-			return getHelmReleaseData(object);
+			return getHelmReleaseData(o);
 		case 'VirtualMachine':
-			return getVirtualMachineData(object);
+			return getVirtualMachineData(o);
 		case 'DataVolume':
-			return getDataVolumeData(object);
+			return getDataVolumeData(o);
 		case 'VirtualMachineInstancetype':
-			return getVirtualMachineInstancetypeData(object);
+			return getVirtualMachineInstancetypeData(o);
 		case 'ObjectBucketClaim':
-			return getObjectBucketClaimData(object);
+			return getObjectBucketClaimData(o);
 		case 'Application':
-			return getApplicationData(object);
+			return getApplicationData(o);
 		case 'Task':
-			return getTaskData(object);
+			return getTaskData(o);
 		case 'Schedule':
-			return getScheduleData(object);
+			return getScheduleData(o);
 		case 'LLMInferenceService':
-			return getLLMInferenceServiceData(object);
+			return getLLMInferenceServiceData(o);
 		case 'LLMInferenceServiceConfig':
-			return getLLMInferenceServiceConfigData(object);
+			return getLLMInferenceServiceConfigData(o);
 		default:
-			return getDefaultData(apiResource, object);
+			return getDefaultData(apiResource, o);
 	}
 }
 

--- a/src/lib/components/kind-viewer/kind-viewers/instancetype.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/instancetype.ts
@@ -1,5 +1,6 @@
 import { type JsonObject, type JsonValue } from '@bufbuild/protobuf';
 import type { APIResource } from '@otterscale/api/resource/v1';
+import type { InstancetypeKubevirtIoV1Beta1VirtualMachineInstancetype } from '@otterscale/types';
 import type { Column, ColumnDef } from '@tanstack/table-core';
 import { type Row } from '@tanstack/table-core';
 
@@ -37,7 +38,7 @@ function getVirtualMachineInstancetypeDataSchemas(): Record<
 }
 
 function getVirtualMachineInstancetypeData(
-	object: any
+	object: InstancetypeKubevirtIoV1Beta1VirtualMachineInstancetype
 ): Record<VirtualMachineInstancetypeAttribute, JsonValue> {
 	const cpuGuest = object?.spec?.cpu?.guest ?? null;
 	const memoryGuest = object?.spec?.memory?.guest ?? null;

--- a/src/lib/components/kind-viewer/kind-viewers/schedule.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/schedule.ts
@@ -35,9 +35,19 @@ function getScheduleDataSchemas(): Record<ScheduleAttribute, DataSchemaType> {
 	};
 }
 
-function getScheduleData(object: any): Record<ScheduleAttribute, JsonValue> {
+type ScheduleObject = {
+	metadata?: { name?: string; namespace?: string; creationTimestamp?: string };
+	spec?: { cronSchedule?: string; suspend?: boolean | string };
+	status?: {
+		state?: string;
+		lastScheduleTime?: string;
+		conditions?: { type?: string; status?: string }[];
+	};
+};
+
+function getScheduleData(object: ScheduleObject): Record<ScheduleAttribute, JsonValue> {
 	const readyCondition = object?.status?.conditions?.find(
-		(condition: any) => condition.type === 'Ready'
+		(condition) => condition.type === 'Ready'
 	);
 
 	return {

--- a/src/lib/components/kind-viewer/kind-viewers/task.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/task.ts
@@ -35,9 +35,20 @@ function getTaskDataSchemas(): Record<TaskAttribute, DataSchemaType> {
 	};
 }
 
-function getTaskData(object: any): Record<TaskAttribute, JsonValue> {
+type TaskObject = {
+	metadata?: { name?: string; namespace?: string; creationTimestamp?: string };
+	spec?: { suspend?: boolean | string };
+	status?: {
+		state?: string;
+		status?: string;
+		completions?: number | string;
+		conditions?: { type?: string; status?: string }[];
+	};
+};
+
+function getTaskData(object: TaskObject): Record<TaskAttribute, JsonValue> {
 	const readyCondition = object?.status?.conditions?.find(
-		(condition: any) => condition.type === 'Ready'
+		(condition) => condition.type === 'Ready'
 	);
 
 	return {

--- a/src/lib/components/kind-viewer/kind-viewers/virtualmachine.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/virtualmachine.ts
@@ -1,5 +1,6 @@
 import { type JsonObject, type JsonValue } from '@bufbuild/protobuf';
 import type { APIResource } from '@otterscale/api/resource/v1';
+import type { KubevirtIoV1VirtualMachine } from '@otterscale/types';
 import type { Column, ColumnDef } from '@tanstack/table-core';
 import { type Row } from '@tanstack/table-core';
 
@@ -44,7 +45,9 @@ function getVirtualMachineDataSchemas(): Record<VirtualMachineAttribute, DataSch
 	};
 }
 
-function getVirtualMachineData(object: any): Record<VirtualMachineAttribute, JsonValue> {
+function getVirtualMachineData(
+	object: KubevirtIoV1VirtualMachine
+): Record<VirtualMachineAttribute, JsonValue> {
 	const instancetype = object?.spec?.instancetype;
 	const instanceTypeDisplay = instancetype
 		? `${instancetype.kind ?? 'VirtualMachineInstancetype'}/${instancetype.name}`
@@ -168,16 +171,16 @@ function getVirtualMachineColumnDefinitions(
 					column,
 					uiSchemas,
 					metadata: {
-						items: ((row.original.raw as any)?.spec?.template?.spec?.volumes ?? []).map(
-							(v: any) => {
-								const volumeType = Object.keys(v).find((k) => k !== 'name') ?? 'unknown';
-								return {
-									title: v.name,
-									description: volumeType,
-									raw: v as JsonObject
-								};
-							}
-						) as ArrayOfObjectItemsType
+						items: (
+							(row.original.raw as KubevirtIoV1VirtualMachine)?.spec?.template?.spec?.volumes ?? []
+						).map((v) => {
+							const volumeType = Object.keys(v).find((k) => k !== 'name') ?? 'unknown';
+							return {
+								title: v.name,
+								description: volumeType,
+								raw: v as JsonObject
+							};
+						}) as ArrayOfObjectItemsType
 					} satisfies ArrayOfObjectMetadata
 				}),
 			accessorKey: 'Volumes',

--- a/src/lib/components/resource-viewer/resource-viewer.svelte
+++ b/src/lib/components/resource-viewer/resource-viewer.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import type { JsonObject } from '@bufbuild/protobuf';
 	import { createClient, type Transport } from '@connectrpc/connect';
 	import Ban from '@lucide/svelte/icons/ban';
 	import Braces from '@lucide/svelte/icons/braces';
@@ -11,6 +12,7 @@
 		WatchEvent_Type,
 		type WatchRequest
 	} from '@otterscale/api/resource/v1';
+	import type { Schema } from '@sjsf/form';
 	import { getContext, onDestroy, onMount } from 'svelte';
 	import { stringify } from 'yaml';
 
@@ -54,9 +56,27 @@
 	const transport: Transport = getContext('transport');
 	const resourceClient = createClient(ResourceService, transport);
 
-	let schema: any | undefined = $state(undefined);
-	let object: any | undefined = $state(undefined);
-	let error: any | null = $state(null);
+	type ResourceObject = {
+		kind?: string;
+		apiVersion?: string;
+		metadata?: {
+			name?: string;
+			namespace?: string;
+			creationTimestamp?: string;
+			generation?: number;
+			resourceVersion?: string;
+			labels?: Record<string, string>;
+			annotations?: Record<string, string>;
+		};
+		status?: {
+			namespaceRef?: { name?: string };
+		};
+	} & JsonObject;
+	type ViewerError = { name?: string; rawMessage?: string; message?: string };
+
+	let schema: Schema | undefined = $state(undefined);
+	let object: ResourceObject | undefined = $state(undefined);
+	let error: ViewerError | null = $state(null);
 
 	let isGetting = $state(false);
 	let getAbortController: AbortController | null = null;
@@ -309,7 +329,9 @@
 							}}
 							{@const creationTimestampData = {
 								name: 'Creation Timestamp',
-								information: new Date(object.metadata?.creationTimestamp).toLocaleString('sv-SE')
+								information: new Date(object.metadata?.creationTimestamp ?? '').toLocaleString(
+									'sv-SE'
+								)
 							}}
 							{@const generationData = {
 								name: 'Generation',
@@ -445,6 +467,8 @@
 				</Item.Footer>
 			</Item.Root>
 		</Field.Set>
-		<Inspector {object} {schema} />
+		{#if object}
+			<Inspector {object} {schema} />
+		{/if}
 	</Field.Group>
 {/if}

--- a/src/lib/components/resource-viewer/viewers/default-viewer.svelte
+++ b/src/lib/components/resource-viewer/viewers/default-viewer.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
+	import type { JsonObject } from '@bufbuild/protobuf';
 	import { stringify } from 'yaml';
 
 	import * as Code from '$lib/components/custom/code';
 
-	let { object }: { object: any } = $props();
+	let { object }: { object: JsonObject } = $props();
 </script>
 
 <Code.Root variant="secondary" lang="yaml" class="w-full border-none" code={stringify(object)} />

--- a/src/lib/components/resource-viewer/viewers/index.ts
+++ b/src/lib/components/resource-viewer/viewers/index.ts
@@ -1,10 +1,12 @@
+import type { JsonObject } from '@bufbuild/protobuf';
+import type { Schema } from '@sjsf/form';
 import type { Component } from 'svelte';
 
 import DefaultViewer from './default-viewer.svelte';
 import WorkspaceEditor from './workspace-editor.svelte';
 import WorkspaceViewer from './workspaces-viewer.svelte';
 
-type ViewerProps = { object: any; schema?: any };
+type ViewerProps = { object: JsonObject; schema?: Schema };
 type ViewerType = Component<ViewerProps>;
 
 type EditorProps = {
@@ -14,8 +16,8 @@ type EditorProps = {
 	version: string;
 	kind: string;
 	resource: string;
-	schema?: any;
-	object?: any;
+	schema?: Schema;
+	object?: JsonObject;
 	onsuccess?: () => void;
 };
 type EditorType = Component<EditorProps> | null;

--- a/src/lib/components/resource-viewer/viewers/rook-ceph-viewer.svelte
+++ b/src/lib/components/resource-viewer/viewers/rook-ceph-viewer.svelte
@@ -53,7 +53,7 @@
 	// AbortController is used to terminate all watch streams when the component is destroyed
 	const abortController = new AbortController();
 
-	const getKey = (o: any) => o?.metadata?.uid ?? o?.metadata?.name ?? '';
+	const getKey = (o: TargetResource) => o?.metadata?.uid ?? o?.metadata?.name ?? '';
 	async function listAndWatch<T extends TargetResource>(
 		identifier: { group: string; version: string; resource: string },
 		setObjects: (items: T[]) => void,
@@ -327,8 +327,7 @@
 						{@const details = cephCluster?.status?.ceph?.details ?? {}}
 						{#if Object.keys(details).length > 0}
 							<div class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-								{#each Object.entries(details) as [key, value] (key)}
-									{@const detail = value as any}
+								{#each Object.entries(details) as [key, detail] (key)}
 									<Item.Root class="p-0">
 										<Item.Content>
 											<Item.Title class="text-sm font-medium"

--- a/src/lib/components/resource-viewer/viewers/workspace-editor.svelte
+++ b/src/lib/components/resource-viewer/viewers/workspace-editor.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import Pencil from '@lucide/svelte/icons/pencil';
+	import type { TenantOtterscaleIoV1Alpha1Workspace } from '@otterscale/types';
+	import type { Schema } from '@sjsf/form';
 
 	import Update from '$lib/components/kind-viewer/kind-viewer-actions/workspace/update.svelte';
 	import Button from '$lib/components/ui/button/button.svelte';
@@ -22,8 +24,8 @@
 		version: string;
 		kind: string;
 		resource: string;
-		schema: any;
-		object?: any;
+		schema: Schema;
+		object?: TenantOtterscaleIoV1Alpha1Workspace;
 		onsuccess?: () => void;
 	} = $props();
 </script>

--- a/src/lib/components/schema-viewer/schema-viewer.svelte
+++ b/src/lib/components/schema-viewer/schema-viewer.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import type { Schema } from '@sjsf/form';
 	import { stringify } from 'yaml';
 
 	import * as Code from '$lib/components/custom/code';
@@ -9,7 +10,8 @@
 	import * as Item from '$lib/components/ui/item';
 	import { cn } from '$lib/utils';
 
-	let { schema: jsonSchema, class: className }: { schema: any; class?: string } = $props();
+	let { schema: jsonSchema, class: className }: { schema: Schema | undefined; class?: string } =
+		$props();
 
 	let path: string[] = $state([]);
 	function navigateTo(key: string) {
@@ -22,27 +24,38 @@
 	const currentSchema = $derived.by(() => {
 		if (!path) return null;
 
-		let node = jsonSchema;
+		let node: Schema | undefined = jsonSchema;
 		for (const segment of path) {
-			if (node?.properties?.[segment]) {
-				node = node.properties[segment];
-			} else if (node?.items?.properties?.[segment]) {
-				node = node.items.properties[segment];
+			const propMatch = node?.properties?.[segment] as Schema | undefined;
+			const itemMatch = (node?.items as Schema | undefined)?.properties?.[segment] as
+				| Schema
+				| undefined;
+			if (propMatch) {
+				node = propMatch;
+			} else if (itemMatch) {
+				node = itemMatch;
 			} else {
 				return null;
 			}
 		}
-		return node;
+		return node ?? null;
 	});
 	const entries = $derived.by(() => {
 		if (!currentSchema) return [];
 
-		const properties = currentSchema.properties ?? currentSchema.items?.properties;
+		const properties = (currentSchema.properties ??
+			(currentSchema.items as Schema | undefined)?.properties) as
+			| Record<string, Schema>
+			| undefined;
 		if (!properties) return [];
-		const required = new Set(currentSchema.required ?? currentSchema.items?.required ?? []);
+		const required = new Set<string>(
+			currentSchema.required ?? (currentSchema.items as Schema | undefined)?.required ?? []
+		);
 
-		return Object.entries(properties).map(([property, propertySchema]: [string, any]) => {
-			const hasChildren = !!(propertySchema.properties || propertySchema.items?.properties);
+		return Object.entries(properties).map(([property, propertySchema]) => {
+			const hasChildren = !!(
+				propertySchema.properties || (propertySchema.items as Schema | undefined)?.properties
+			);
 			return {
 				key: property,
 				description: propertySchema.description ?? '',
@@ -54,13 +67,13 @@
 		});
 	});
 
-	function resolveType(schema: any): string {
-		if (schema.type && schema.format) return `${schema.type} | ${schema.format}`;
-		if (schema.type) return schema.type;
+	function resolveType(schema: Schema): string {
+		if (schema.type && schema.format) return `${String(schema.type)} | ${schema.format}`;
+		if (schema.type) return String(schema.type);
 		return 'unknown';
 	}
 
-	function getConstraints(schema: any): object {
+	function getConstraints(schema: Schema): object {
 		const excludedProperties = ['description', 'required', 'type', 'format', 'properties', 'items'];
 		const constraitns = Object.fromEntries(
 			Object.entries(schema).filter(([key]) => !excludedProperties.includes(key))

--- a/src/lib/utils/gpu-node-utils.ts
+++ b/src/lib/utils/gpu-node-utils.ts
@@ -1,5 +1,6 @@
 import type { Client } from '@connectrpc/connect';
-import type { ResourceService } from '@otterscale/api/resource/v1';
+import type { Resource, ResourceService } from '@otterscale/api/resource/v1';
+import type { CoreV1Node } from '@otterscale/types';
 
 type ResourceClient = Client<typeof ResourceService>;
 
@@ -16,7 +17,7 @@ const GPU_PASSTHROUGH_LABELS = {
 export async function fetchNodesWithVmxLabel(
 	resourceClient: ResourceClient,
 	cluster: string
-): Promise<any[]> {
+): Promise<Resource[]> {
 	try {
 		const response = await resourceClient.list({
 			cluster,
@@ -24,8 +25,8 @@ export async function fetchNodesWithVmxLabel(
 			version: 'v1',
 			resource: 'nodes'
 		});
-		return response.items.filter((item: any) => {
-			const nodeLabels = (item.object as any)?.metadata?.labels ?? {};
+		return response.items.filter((item) => {
+			const nodeLabels = (item.object as CoreV1Node)?.metadata?.labels ?? {};
 			return nodeLabels['cpu-feature.node.kubevirt.io/vmx'] === 'true';
 		});
 	} catch (error) {
@@ -37,7 +38,7 @@ export async function fetchNodesWithVmxLabel(
 export async function fetchNodesWithGpuPassthrough(
 	resourceClient: ResourceClient,
 	cluster: string
-): Promise<any[]> {
+): Promise<Resource[]> {
 	try {
 		const response = await resourceClient.list({
 			cluster,
@@ -45,8 +46,8 @@ export async function fetchNodesWithGpuPassthrough(
 			version: 'v1',
 			resource: 'nodes'
 		});
-		return response.items.filter((item: any) => {
-			const nodeLabels = (item.object as any)?.metadata?.labels ?? {};
+		return response.items.filter((item) => {
+			const nodeLabels = (item.object as CoreV1Node)?.metadata?.labels ?? {};
 			return Object.entries(GPU_PASSTHROUGH_LABELS).every(
 				([key, value]) => nodeLabels[key] === value
 			);
@@ -67,16 +68,16 @@ export async function fetchAllGpuResources(
 		const quantities = new Map<string, number>();
 
 		for (const nodeItem of nodes) {
-			const allocatable = (nodeItem.object as any)?.status?.allocatable ?? {};
+			const allocatable = (nodeItem.object as CoreV1Node)?.status?.allocatable ?? {};
 			Object.keys(allocatable).forEach((resourceKey) => {
 				if (
 					resourceKey.startsWith('nvidia.com/') &&
 					!resourceKey.endsWith('vgpu') &&
 					!resourceKey.includes('/vgpu') &&
-					parseInt(allocatable[resourceKey]) > 0
+					parseInt(String(allocatable[resourceKey])) > 0
 				) {
 					gpuResources.add(resourceKey);
-					const quantity = parseInt(allocatable[resourceKey]) || 0;
+					const quantity = parseInt(String(allocatable[resourceKey])) || 0;
 					const currentMax = quantities.get(resourceKey) || 0;
 					if (quantity > currentMax) {
 						quantities.set(resourceKey, quantity);
@@ -107,7 +108,7 @@ export async function fetchGpuResourcesForNode(
 			name: nodeName
 		});
 
-		const nodeObj = response.object as any;
+		const nodeObj = response.object as CoreV1Node;
 		const nodeLabels = nodeObj?.metadata?.labels ?? {};
 		const hasGpuWorkloadConfig = nodeLabels['nvidia.com/gpu.workload.config'] === 'vm-passthrough';
 		const hasGpuPresent = nodeLabels['nvidia.com/gpu.present'] === 'true';
@@ -126,10 +127,10 @@ export async function fetchGpuResourcesForNode(
 				resourceKey.startsWith('nvidia.com/') &&
 				!resourceKey.endsWith('vgpu') &&
 				!resourceKey.includes('/vgpu') &&
-				parseInt(allocatable[resourceKey]) > 0
+				parseInt(String(allocatable[resourceKey])) > 0
 			) {
 				gpuResources.push(resourceKey);
-				quantities.set(resourceKey, parseInt(allocatable[resourceKey]) || 0);
+				quantities.set(resourceKey, parseInt(String(allocatable[resourceKey])) || 0);
 			}
 		});
 


### PR DESCRIPTION
Tightens types and refactors module-scope prop reads across dashboard, kind-viewer, resource-viewer, schema-viewer, and gpu-node-utils to clear all `@typescript-eslint/no-explicit-any` and Svelte `state_referenced_locally` warnings.

- Replace `any` with concrete @otterscale/types, JsonObject, Schema (@sjsf/form), or local minimal types where K8s types don't exist (Application, Task, Schedule CRDs).
- Extract `getInitialValues()` helpers so `$state(...)` no longer captures props at module scope (compute/model dashboard, llm-inference-service create/update).
- Move workload-health's `prometheusDriver` suppression into the existing onMount closure.
- Refactor datavolume.ts source dispatch from dynamic `Object.keys().find()` to typed `if (source.http) ...` branches.
- Widen ViewerProps/ActionsType in resource-viewer/viewers and kind-viewer-actions to JsonObject + Row<Record<string,JsonValue>>; call sites updated.
- Use `as never` once in kind-viewers/index.ts getData() to satisfy 38 per-Kind dispatch calls without per-case casts.