### PR TITLE
feat: add copy button to all Code blocks

### DIFF
--- a/src/lib/components/artifact-viewer/artifact-viewer-actions/upload.svelte
+++ b/src/lib/components/artifact-viewer/artifact-viewer-actions/upload.svelte
@@ -90,7 +90,9 @@
 										2
 									)}
 									hideLines
-								/>
+								>
+									<Code.CopyButton />
+								</Code.Root>
 							</div>
 						</Collapsible.Content>
 					</Collapsible.Root>
@@ -109,7 +111,9 @@
 										'\n'
 									)}
 									hideLines
-								/>
+								>
+									<Code.CopyButton />
+								</Code.Root>
 							</div>
 						</Collapsible.Content>
 					</Collapsible.Root>

--- a/src/lib/components/artifact-viewer/artifact-viewer-actions/view.svelte
+++ b/src/lib/components/artifact-viewer/artifact-viewer-actions/view.svelte
@@ -49,6 +49,8 @@
 			lang="yaml"
 			code={stringify(row.original.chart)}
 			class="w-full border-none"
-		/>
+		>
+			<Code.CopyButton />
+		</Code.Root>
 	</Dialog.Content>
 </Dialog.Root>

--- a/src/lib/components/dynamic-table/dynamic-table-cells/object-cell.svelte
+++ b/src/lib/components/dynamic-table/dynamic-table-cells/object-cell.svelte
@@ -109,7 +109,9 @@
 											hideLines
 											code={formatted}
 											class="border-none bg-transparent px-8"
-										/>
+										>
+											<Code.CopyButton />
+										</Code.Root>
 									</Collapsible.Content>
 								</Collapsible.Root>
 							{/if}

--- a/src/lib/components/dynamic-table/dynamic-table-cells/object-of-key-value-cell.svelte
+++ b/src/lib/components/dynamic-table/dynamic-table-cells/object-of-key-value-cell.svelte
@@ -116,7 +116,9 @@
 											hideLines
 											code={formatted}
 											class="border-none bg-transparent px-8"
-										/>
+										>
+											<Code.CopyButton />
+										</Code.Root>
 									</Collapsible.Content>
 								</Collapsible.Root>
 							{/if}

--- a/src/lib/components/kind-viewer/kind-viewer-actions/ceph-object-bucket-claim/download.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/ceph-object-bucket-claim/download.svelte
@@ -130,7 +130,9 @@ curl -s "http://${endpoint}/${bucketName}/$KEY" \\
   -H "Authorization: AWS $ACCESS_KEY:$SIGNATURE" \\
   -o "$KEY"\
 `}
-				<Code.Root lang="bash" code={command} hideLines />
+				<Code.Root lang="bash" code={command} hideLines>
+					<Code.CopyButton />
+				</Code.Root>
 				<Button
 					class="mt-auto w-full"
 					onclick={() => {

--- a/src/lib/components/kind-viewer/kind-viewer-actions/ceph-object-bucket-claim/list.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/ceph-object-bucket-claim/list.svelte
@@ -128,7 +128,9 @@ curl -s "http://${endpoint}/${bucketName}/" \\
   -H "Date: $TIMESTAMP" \\
   -H "Authorization: AWS $ACCESS_KEY:$SIGNATURE"\
 `}
-				<Code.Root lang="bash" code={command} hideLines />
+				<Code.Root lang="bash" code={command} hideLines>
+					<Code.CopyButton />
+				</Code.Root>
 				<Button
 					class="mt-auto w-full"
 					onclick={() => {

--- a/src/lib/components/kind-viewer/kind-viewer-actions/ceph-object-bucket-claim/remove.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/ceph-object-bucket-claim/remove.svelte
@@ -129,7 +129,9 @@ curl -X DELETE "http://${endpoint}/${bucketName}/$KEY" \\
   -H "Date: $TIMESTAMP" \\
   -H "Authorization: AWS $ACCESS_KEY:$SIGNATURE"\
 `}
-				<Code.Root lang="bash" code={command} hideLines />
+				<Code.Root lang="bash" code={command} hideLines>
+					<Code.CopyButton />
+				</Code.Root>
 				<Button
 					class="mt-auto w-full"
 					onclick={() => {

--- a/src/lib/components/kind-viewer/kind-viewer-actions/ceph-object-bucket-claim/upload.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/ceph-object-bucket-claim/upload.svelte
@@ -134,7 +134,9 @@ curl -X PUT "http://${endpoint}/${bucketName}/$KEY" \\
   -H "Authorization: AWS $ACCESS_KEY:$SIGNATURE" \\
   -T "$FILE"\
 `}
-				<Code.Root lang="bash" code={command} hideLines />
+				<Code.Root lang="bash" code={command} hideLines>
+					<Code.CopyButton />
+				</Code.Root>
 				<Button
 					class="mt-auto w-full"
 					onclick={() => {

--- a/src/lib/components/kind-viewer/kind-viewer-actions/default/view.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/default/view.svelte
@@ -43,11 +43,8 @@
 				</Item.Content>
 			</Item.Root>
 		</Dialog.Header>
-		<Code.Root
-			variant="secondary"
-			lang="yaml"
-			code={stringify(object)}
-			class="w-full border-none"
-		/>
+		<Code.Root variant="secondary" lang="yaml" code={stringify(object)} class="w-full border-none">
+			<Code.CopyButton />
+		</Code.Root>
 	</Dialog.Content>
 </Dialog.Root>

--- a/src/lib/components/module-viewer/module-viewer-actions/view.svelte
+++ b/src/lib/components/module-viewer/module-viewer-actions/view.svelte
@@ -49,6 +49,8 @@
 			lang="yaml"
 			code={stringify(row.original['chart'])}
 			class="w-full border-none"
-		/>
+		>
+			<Code.CopyButton />
+		</Code.Root>
 	</Dialog.Content>
 </Dialog.Root>

--- a/src/lib/components/resource-viewer/resource-viewer.svelte
+++ b/src/lib/components/resource-viewer/resource-viewer.svelte
@@ -389,7 +389,9 @@
 												code={stringify(object)}
 												lang="yaml"
 												class="no-shiki-limit m-4 border-none bg-muted"
-											/>
+											>
+												<Code.CopyButton />
+											</Code.Root>
 										{:else}
 											<Empty.Root class="m-4 bg-muted/50">
 												<Empty.Header>

--- a/src/lib/components/resource-viewer/viewers/default-viewer.svelte
+++ b/src/lib/components/resource-viewer/viewers/default-viewer.svelte
@@ -7,4 +7,6 @@
 	let { object }: { object: JsonObject } = $props();
 </script>
 
-<Code.Root variant="secondary" lang="yaml" class="w-full border-none" code={stringify(object)} />
+<Code.Root variant="secondary" lang="yaml" class="w-full border-none" code={stringify(object)}>
+	<Code.CopyButton />
+</Code.Root>

--- a/src/lib/components/schema-viewer/schema-viewer.svelte
+++ b/src/lib/components/schema-viewer/schema-viewer.svelte
@@ -189,11 +189,8 @@
 			{/each}
 		</div>
 	{:else if currentSchema}
-		<Code.Root
-			class="h-fit w-full"
-			lang="yaml"
-			code={stringify(currentSchema, null, 2)}
-			hideLines
-		/>
+		<Code.Root class="h-fit w-full" lang="yaml" code={stringify(currentSchema, null, 2)} hideLines>
+			<Code.CopyButton />
+		</Code.Root>
 	{/if}
 </main>


### PR DESCRIPTION
Nest <Code.CopyButton /> inside every <Code.Root> across kind-viewer, artifact-viewer, module-viewer, resource-viewer, schema-viewer, and dynamic-table cells so users can copy rendered YAML / JSON / bash snippets directly.