### PR TITLE
feat: hide Namespace by default and improve column ordering in kind-v…

### DIFF
--- a/src/lib/components/dynamic-table/dynamic-table.svelte
+++ b/src/lib/components/dynamic-table/dynamic-table.svelte
@@ -167,7 +167,14 @@
 
 	let rowSelection = $state<RowSelectionState>({});
 	let columnFilters = $state<ColumnFiltersState>([]);
-	let columnVisibility = $state<VisibilityState>({});
+	// svelte-ignore state_referenced_locally
+	const initialColumnVisibility: VisibilityState = Object.fromEntries(
+		columnDefinitions
+			.filter((col) => (col.meta as { defaultHidden?: boolean } | undefined)?.defaultHidden === true)
+			.map((col) => [col.id ?? (col as { accessorKey?: string }).accessorKey, false])
+			.filter(([id]) => id != null)
+	);
+	let columnVisibility = $state<VisibilityState>(initialColumnVisibility);
 	let columnSizing = $state<ColumnSizingState>({});
 	let sorting = $state<SortingState>([]);
 	let pagination = $state<PaginationState>({ pageIndex: 0, pageSize: hasGridlayout ? 9 : 10 });

--- a/src/lib/components/dynamic-table/dynamic-table.svelte
+++ b/src/lib/components/dynamic-table/dynamic-table.svelte
@@ -170,7 +170,9 @@
 	// svelte-ignore state_referenced_locally
 	const initialColumnVisibility: VisibilityState = Object.fromEntries(
 		columnDefinitions
-			.filter((col) => (col.meta as { defaultHidden?: boolean } | undefined)?.defaultHidden === true)
+			.filter(
+				(col) => (col.meta as { defaultHidden?: boolean } | undefined)?.defaultHidden === true
+			)
 			.map((col) => [col.id ?? (col as { accessorKey?: string }).accessorKey, false])
 			.filter(([id]) => id != null)
 	);

--- a/src/lib/components/kind-viewer/kind-viewers/application.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/application.ts
@@ -131,7 +131,8 @@ function getApplicationColumnDefinitions(
 					column: column,
 					uiSchemas: uiSchemas
 				}),
-			accessorKey: 'Namespace'
+			accessorKey: 'Namespace',
+			meta: { defaultHidden: true }
 		},
 		{
 			id: 'State',

--- a/src/lib/components/kind-viewer/kind-viewers/configmap.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/configmap.ts
@@ -105,7 +105,8 @@ function getConfigMapColumnDefinitions(
 					column: column,
 					uiSchemas: uiSchemas
 				}),
-			accessorKey: 'Namespace'
+			accessorKey: 'Namespace',
+			meta: { defaultHidden: true }
 		},
 		{
 			id: 'Data',

--- a/src/lib/components/kind-viewer/kind-viewers/cronjob.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/cronjob.ts
@@ -135,7 +135,8 @@ function getCronJobColumnDefinitions(
 					column: column,
 					uiSchemas: uiSchemas
 				}),
-			accessorKey: 'Namespace'
+			accessorKey: 'Namespace',
+			meta: { defaultHidden: true }
 		},
 		{
 			id: 'Schedule',
@@ -157,27 +158,6 @@ function getCronJobColumnDefinitions(
 					uiSchemas: uiSchemas
 				}),
 			accessorKey: 'Schedule'
-		},
-		{
-			id: 'Time Zone',
-			header: ({ column }: { column: Column<Record<CronJobAttribute, JsonValue>> }) =>
-				renderComponent(DynamicTableHeader, {
-					column: column,
-					dataSchemas: dataSchemas
-				}),
-			cell: ({
-				column,
-				row
-			}: {
-				column: Column<Record<CronJobAttribute, JsonValue>>;
-				row: Row<Record<CronJobAttribute, JsonValue>>;
-			}) =>
-				renderComponent(DynamicTableCell, {
-					row: row,
-					column: column,
-					uiSchemas: uiSchemas
-				}),
-			accessorKey: 'Time Zone'
 		},
 		{
 			id: 'Suspend',
@@ -254,7 +234,7 @@ function getCronJobColumnDefinitions(
 			accessorKey: 'Last Schedule'
 		},
 		{
-			id: 'Creation Timestamp',
+			id: 'Time Zone',
 			header: ({ column }: { column: Column<Record<CronJobAttribute, JsonValue>> }) =>
 				renderComponent(DynamicTableHeader, {
 					column: column,
@@ -272,7 +252,8 @@ function getCronJobColumnDefinitions(
 					column: column,
 					uiSchemas: uiSchemas
 				}),
-			accessorKey: 'Creation Timestamp'
+			accessorKey: 'Time Zone',
+			meta: { defaultHidden: true }
 		},
 		{
 			id: 'Containers',
@@ -344,6 +325,28 @@ function getCronJobColumnDefinitions(
 			meta: {
 				class: 'hidden xl:table-cell'
 			}
+		},
+		{
+			id: 'Creation Timestamp',
+			header: ({ column }: { column: Column<Record<CronJobAttribute, JsonValue>> }) =>
+				renderComponent(DynamicTableHeader, {
+					column: column,
+					dataSchemas: dataSchemas
+				}),
+			cell: ({
+				column,
+				row
+			}: {
+				column: Column<Record<CronJobAttribute, JsonValue>>;
+				row: Row<Record<CronJobAttribute, JsonValue>>;
+			}) =>
+				renderComponent(DynamicTableCell, {
+					row: row,
+					column: column,
+					uiSchemas: uiSchemas
+				}),
+			accessorKey: 'Creation Timestamp',
+			meta: { defaultHidden: true }
 		}
 	];
 }

--- a/src/lib/components/kind-viewer/kind-viewers/daemonset.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/daemonset.ts
@@ -144,7 +144,8 @@ function getDaemonSetColumnDefinitions(
 					column: column,
 					uiSchemas: uiSchemas
 				}),
-			accessorKey: 'Namespace'
+			accessorKey: 'Namespace',
+			meta: { defaultHidden: true }
 		},
 		{
 			id: 'Desired',
@@ -228,7 +229,8 @@ function getDaemonSetColumnDefinitions(
 					column: column,
 					uiSchemas: uiSchemas
 				}),
-			accessorKey: 'Up-To-Date'
+			accessorKey: 'Up-To-Date',
+			meta: { defaultHidden: true }
 		},
 		{
 			id: 'Available',
@@ -249,7 +251,8 @@ function getDaemonSetColumnDefinitions(
 					column: column,
 					uiSchemas: uiSchemas
 				}),
-			accessorKey: 'Available'
+			accessorKey: 'Available',
+			meta: { defaultHidden: true }
 		},
 		{
 			id: 'Node Selector',
@@ -283,27 +286,6 @@ function getDaemonSetColumnDefinitions(
 			meta: {
 				class: 'hidden xl:table-cell'
 			}
-		},
-		{
-			id: 'Age',
-			header: ({ column }: { column: Column<Record<DaemonSetAttribute, JsonValue>> }) =>
-				renderComponent(DynamicTableHeader, {
-					column: column,
-					dataSchemas: dataSchemas
-				}),
-			cell: ({
-				column,
-				row
-			}: {
-				column: Column<Record<DaemonSetAttribute, JsonValue>>;
-				row: Row<Record<DaemonSetAttribute, JsonValue>>;
-			}) =>
-				renderComponent(DynamicTableCell, {
-					row: row,
-					column: column,
-					uiSchemas: uiSchemas
-				}),
-			accessorKey: 'Age'
 		},
 		{
 			id: 'Containers',
@@ -408,6 +390,27 @@ function getDaemonSetColumnDefinitions(
 			meta: {
 				class: 'hidden xl:table-cell'
 			}
+		},
+		{
+			id: 'Age',
+			header: ({ column }: { column: Column<Record<DaemonSetAttribute, JsonValue>> }) =>
+				renderComponent(DynamicTableHeader, {
+					column: column,
+					dataSchemas: dataSchemas
+				}),
+			cell: ({
+				column,
+				row
+			}: {
+				column: Column<Record<DaemonSetAttribute, JsonValue>>;
+				row: Row<Record<DaemonSetAttribute, JsonValue>>;
+			}) =>
+				renderComponent(DynamicTableCell, {
+					row: row,
+					column: column,
+					uiSchemas: uiSchemas
+				}),
+			accessorKey: 'Age'
 		}
 	];
 }

--- a/src/lib/components/kind-viewer/kind-viewers/datavolume.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/datavolume.ts
@@ -174,7 +174,8 @@ function getDataVolumeColumnDefinitions(
 					column,
 					uiSchemas
 				}),
-			accessorKey: 'Namespace'
+			accessorKey: 'Namespace',
+			meta: { defaultHidden: true }
 		},
 		simpleColumn('Phase'),
 		simpleColumn('Progress'),

--- a/src/lib/components/kind-viewer/kind-viewers/default.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/default.ts
@@ -121,7 +121,8 @@ function getDefaultColumnDefinitions(
 						column: column,
 						uiSchemas: uiSchemas
 					}),
-				accessorKey: 'Namespace'
+				accessorKey: 'Namespace',
+				meta: { defaultHidden: true }
 			}
 		].filter(() => apiResource!.namespaced),
 		{

--- a/src/lib/components/kind-viewer/kind-viewers/deployment.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/deployment.ts
@@ -133,7 +133,8 @@ function getDeploymentColumnDefinitions(
 					column: column,
 					uiSchemas: uiSchemas
 				}),
-			accessorKey: 'Namespace'
+			accessorKey: 'Namespace',
+			meta: { defaultHidden: true }
 		},
 		{
 			id: 'Ready',
@@ -197,27 +198,6 @@ function getDeploymentColumnDefinitions(
 					uiSchemas: uiSchemas
 				}),
 			accessorKey: 'Available'
-		},
-		{
-			id: 'Age',
-			header: ({ column }: { column: Column<Record<DeploymentAttribute, JsonValue>> }) =>
-				renderComponent(DynamicTableHeader, {
-					column: column,
-					dataSchemas: dataSchemas
-				}),
-			cell: ({
-				column,
-				row
-			}: {
-				column: Column<Record<DeploymentAttribute, JsonValue>>;
-				row: Row<Record<DeploymentAttribute, JsonValue>>;
-			}) =>
-				renderComponent(DynamicTableCell, {
-					row: row,
-					column: column,
-					uiSchemas: uiSchemas
-				}),
-			accessorKey: 'Age'
 		},
 		{
 			id: 'Containers',
@@ -322,6 +302,27 @@ function getDeploymentColumnDefinitions(
 			meta: {
 				class: 'hidden xl:table-cell'
 			}
+		},
+		{
+			id: 'Age',
+			header: ({ column }: { column: Column<Record<DeploymentAttribute, JsonValue>> }) =>
+				renderComponent(DynamicTableHeader, {
+					column: column,
+					dataSchemas: dataSchemas
+				}),
+			cell: ({
+				column,
+				row
+			}: {
+				column: Column<Record<DeploymentAttribute, JsonValue>>;
+				row: Row<Record<DeploymentAttribute, JsonValue>>;
+			}) =>
+				renderComponent(DynamicTableCell, {
+					row: row,
+					column: column,
+					uiSchemas: uiSchemas
+				}),
+			accessorKey: 'Age'
 		}
 	];
 }

--- a/src/lib/components/kind-viewer/kind-viewers/event.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/event.ts
@@ -136,7 +136,8 @@ function getEventColumnDefinitions(
 					column,
 					uiSchemas
 				}),
-			accessorKey: 'Namespace'
+			accessorKey: 'Namespace',
+			meta: { defaultHidden: true }
 		},
 		simpleColumn('Type'),
 		simpleColumn('Reason'),

--- a/src/lib/components/kind-viewer/kind-viewers/gateway.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/gateway.ts
@@ -114,7 +114,8 @@ function getGatewayColumnDefinitions(
 					column: column,
 					uiSchemas: uiSchemas
 				}),
-			accessorKey: 'Namespace'
+			accessorKey: 'Namespace',
+			meta: { defaultHidden: true }
 		},
 		{
 			id: 'Class',

--- a/src/lib/components/kind-viewer/kind-viewers/helm-release.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/helm-release.ts
@@ -127,7 +127,8 @@ function getHelmReleaseColumnDefinitions(
 					column: column,
 					uiSchemas: uiSchemas
 				}),
-			accessorKey: 'Namespace'
+			accessorKey: 'Namespace',
+			meta: { defaultHidden: true }
 		},
 		{
 			id: 'Repository',

--- a/src/lib/components/kind-viewer/kind-viewers/helm-repository.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/helm-repository.ts
@@ -127,7 +127,8 @@ function getHelmRepositoryColumnDefinitions(
 					column: column,
 					uiSchemas: uiSchemas
 				}),
-			accessorKey: 'Namespace'
+			accessorKey: 'Namespace',
+			meta: { defaultHidden: true }
 		},
 		{
 			id: 'Type',

--- a/src/lib/components/kind-viewer/kind-viewers/httproute.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/httproute.ts
@@ -107,7 +107,8 @@ function getHTTPRouteColumnDefinitions(
 					column: column,
 					uiSchemas: uiSchemas
 				}),
-			accessorKey: 'Namespace'
+			accessorKey: 'Namespace',
+			meta: { defaultHidden: true }
 		},
 		{
 			id: 'Hostnames',

--- a/src/lib/components/kind-viewer/kind-viewers/instancetype.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/instancetype.ts
@@ -145,7 +145,8 @@ function getVirtualMachineInstancetypeColumnDefinitions(
 					column,
 					uiSchemas
 				}),
-			accessorKey: 'Namespace'
+			accessorKey: 'Namespace',
+			meta: { defaultHidden: true }
 		},
 		simpleColumn('CPU'),
 		simpleColumn('Memory'),

--- a/src/lib/components/kind-viewer/kind-viewers/job.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/job.ts
@@ -143,7 +143,8 @@ function getJobColumnDefinitions(
 					column: column,
 					uiSchemas: uiSchemas
 				}),
-			accessorKey: 'Namespace'
+			accessorKey: 'Namespace',
+			meta: { defaultHidden: true }
 		},
 		{
 			id: 'Completions',
@@ -186,27 +187,6 @@ function getJobColumnDefinitions(
 					uiSchemas: uiSchemas
 				}),
 			accessorKey: 'Duration'
-		},
-		{
-			id: 'Age',
-			header: ({ column }: { column: Column<Record<JobAttribute, JsonValue>> }) =>
-				renderComponent(DynamicTableHeader, {
-					column: column,
-					dataSchemas: dataSchemas
-				}),
-			cell: ({
-				column,
-				row
-			}: {
-				column: Column<Record<JobAttribute, JsonValue>>;
-				row: Row<Record<JobAttribute, JsonValue>>;
-			}) =>
-				renderComponent(DynamicTableCell, {
-					row: row,
-					column: column,
-					uiSchemas: uiSchemas
-				}),
-			accessorKey: 'Age'
 		},
 		{
 			id: 'Containers',
@@ -311,6 +291,27 @@ function getJobColumnDefinitions(
 			meta: {
 				class: 'hidden xl:table-cell'
 			}
+		},
+		{
+			id: 'Age',
+			header: ({ column }: { column: Column<Record<JobAttribute, JsonValue>> }) =>
+				renderComponent(DynamicTableHeader, {
+					column: column,
+					dataSchemas: dataSchemas
+				}),
+			cell: ({
+				column,
+				row
+			}: {
+				column: Column<Record<JobAttribute, JsonValue>>;
+				row: Row<Record<JobAttribute, JsonValue>>;
+			}) =>
+				renderComponent(DynamicTableCell, {
+					row: row,
+					column: column,
+					uiSchemas: uiSchemas
+				}),
+			accessorKey: 'Age'
 		}
 	];
 }

--- a/src/lib/components/kind-viewer/kind-viewers/limitrange.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/limitrange.ts
@@ -114,7 +114,8 @@ function getLimitRangeColumnDefinitions(
 					column,
 					uiSchemas
 				}),
-			accessorKey: 'Namespace'
+			accessorKey: 'Namespace',
+			meta: { defaultHidden: true }
 		},
 		{
 			id: 'Limits',

--- a/src/lib/components/kind-viewer/kind-viewers/llm-inference-service-config.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/llm-inference-service-config.ts
@@ -140,7 +140,8 @@ function getLLMInferenceServiceConfigColumnDefinitions(
 					column: column,
 					uiSchemas: uiSchemas
 				}),
-			accessorKey: 'Namespace'
+			accessorKey: 'Namespace',
+			meta: { defaultHidden: true }
 		},
 		{
 			id: 'Model Name',

--- a/src/lib/components/kind-viewer/kind-viewers/llm-inference-service.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/llm-inference-service.ts
@@ -153,7 +153,8 @@ function getLLMInferenceServiceColumnDefinitions(
 					column: column,
 					uiSchemas: uiSchemas
 				}),
-			accessorKey: 'Namespace'
+			accessorKey: 'Namespace',
+			meta: { defaultHidden: true }
 		},
 		{
 			id: 'Model Name',

--- a/src/lib/components/kind-viewer/kind-viewers/networkpolicy.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/networkpolicy.ts
@@ -117,7 +117,8 @@ function getNetworkPolicyColumnDefinitions(
 					column: column,
 					uiSchemas: uiSchemas
 				}),
-			accessorKey: 'Namespace'
+			accessorKey: 'Namespace',
+			meta: { defaultHidden: true }
 		},
 		{
 			id: 'Pod-Selector',

--- a/src/lib/components/kind-viewer/kind-viewers/persistentvolumeclaim.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/persistentvolumeclaim.ts
@@ -138,7 +138,8 @@ function getPVCColumnDefinitions(
 					column,
 					uiSchemas
 				}),
-			accessorKey: 'Namespace'
+			accessorKey: 'Namespace',
+			meta: { defaultHidden: true }
 		},
 		simpleTextColumn('Status'),
 		simpleTextColumn('Volume'),

--- a/src/lib/components/kind-viewer/kind-viewers/pod.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/pod.ts
@@ -221,7 +221,8 @@ function getPodColumnDefinitions(
 					column: column,
 					uiSchemas: uiSchemas
 				}),
-			accessorKey: 'Namespace'
+			accessorKey: 'Namespace',
+			meta: { defaultHidden: true }
 		},
 		{
 			id: 'Ready',
@@ -285,27 +286,6 @@ function getPodColumnDefinitions(
 					uiSchemas: uiSchemas
 				}),
 			accessorKey: 'Restarts'
-		},
-		{
-			id: 'Age',
-			header: ({ column }: { column: Column<Record<PodAttribute, JsonValue>> }) =>
-				renderComponent(DynamicTableHeader, {
-					column: column,
-					dataSchemas: dataSchemas
-				}),
-			cell: ({
-				column,
-				row
-			}: {
-				column: Column<Record<PodAttribute, JsonValue>>;
-				row: Row<Record<PodAttribute, JsonValue>>;
-			}) =>
-				renderComponent(DynamicTableCell, {
-					row: row,
-					column: column,
-					uiSchemas: uiSchemas
-				}),
-			accessorKey: 'Age'
 		},
 		{
 			id: 'IP',
@@ -408,6 +388,27 @@ function getPodColumnDefinitions(
 			meta: {
 				class: 'hidden xl:table-cell'
 			}
+		},
+		{
+			id: 'Age',
+			header: ({ column }: { column: Column<Record<PodAttribute, JsonValue>> }) =>
+				renderComponent(DynamicTableHeader, {
+					column: column,
+					dataSchemas: dataSchemas
+				}),
+			cell: ({
+				column,
+				row
+			}: {
+				column: Column<Record<PodAttribute, JsonValue>>;
+				row: Row<Record<PodAttribute, JsonValue>>;
+			}) =>
+				renderComponent(DynamicTableCell, {
+					row: row,
+					column: column,
+					uiSchemas: uiSchemas
+				}),
+			accessorKey: 'Age'
 		}
 	];
 }

--- a/src/lib/components/kind-viewer/kind-viewers/resource-quota.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/resource-quota.ts
@@ -140,7 +140,8 @@ function getResourceQuotaColumnDefinitions(
 					column: column,
 					uiSchemas: uiSchemas
 				}),
-			accessorKey: 'Namespace'
+			accessorKey: 'Namespace',
+			meta: { defaultHidden: true }
 		},
 		{
 			id: 'CPU Limit',

--- a/src/lib/components/kind-viewer/kind-viewers/role.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/role.ts
@@ -110,7 +110,8 @@ function getRoleColumnDefinitions(
 					column,
 					uiSchemas
 				}),
-			accessorKey: 'Namespace'
+			accessorKey: 'Namespace',
+			meta: { defaultHidden: true }
 		},
 		simpleColumn('Rules'),
 		simpleColumn('Age')

--- a/src/lib/components/kind-viewer/kind-viewers/rolebinding.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/rolebinding.ts
@@ -122,7 +122,8 @@ function getRoleBindingColumnDefinitions(
 					column,
 					uiSchemas
 				}),
-			accessorKey: 'Namespace'
+			accessorKey: 'Namespace',
+			meta: { defaultHidden: true }
 		},
 		simpleColumn('Role'),
 		simpleColumn('Age'),

--- a/src/lib/components/kind-viewer/kind-viewers/schedule.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/schedule.ts
@@ -135,7 +135,8 @@ function getScheduleColumnDefinitions(
 					column: column,
 					uiSchemas: uiSchemas
 				}),
-			accessorKey: 'Namespace'
+			accessorKey: 'Namespace',
+			meta: { defaultHidden: true }
 		},
 		{
 			id: 'State',

--- a/src/lib/components/kind-viewer/kind-viewers/secret.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/secret.ts
@@ -103,7 +103,8 @@ function getSecretColumnDefinitions(
 					column: column,
 					uiSchemas: uiSchemas
 				}),
-			accessorKey: 'Namespace'
+			accessorKey: 'Namespace',
+			meta: { defaultHidden: true }
 		},
 		{
 			id: 'Type',

--- a/src/lib/components/kind-viewer/kind-viewers/service.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/service.ts
@@ -132,7 +132,8 @@ function getServiceColumnDefinitions(
 					column: column,
 					uiSchemas: uiSchemas
 				}),
-			accessorKey: 'Namespace'
+			accessorKey: 'Namespace',
+			meta: { defaultHidden: true }
 		},
 		{
 			id: 'Type',

--- a/src/lib/components/kind-viewer/kind-viewers/serviceaccount.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/serviceaccount.ts
@@ -112,7 +112,8 @@ function getServiceAccountColumnDefinitions(
 					column,
 					uiSchemas
 				}),
-			accessorKey: 'Namespace'
+			accessorKey: 'Namespace',
+			meta: { defaultHidden: true }
 		},
 		simpleColumn('Secrets'),
 		simpleColumn('Age')

--- a/src/lib/components/kind-viewer/kind-viewers/statefulset.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/statefulset.ts
@@ -120,7 +120,8 @@ function getStatefulSetColumnDefinitions(
 					column: column,
 					uiSchemas: uiSchemas
 				}),
-			accessorKey: 'Namespace'
+			accessorKey: 'Namespace',
+			meta: { defaultHidden: true }
 		},
 		{
 			id: 'Ready',
@@ -142,27 +143,6 @@ function getStatefulSetColumnDefinitions(
 					uiSchemas: uiSchemas
 				}),
 			accessorKey: 'Ready'
-		},
-		{
-			id: 'Age',
-			header: ({ column }: { column: Column<Record<StatefulSetAttribute, JsonValue>> }) =>
-				renderComponent(DynamicTableHeader, {
-					column: column,
-					dataSchemas: dataSchemas
-				}),
-			cell: ({
-				column,
-				row
-			}: {
-				column: Column<Record<StatefulSetAttribute, JsonValue>>;
-				row: Row<Record<StatefulSetAttribute, JsonValue>>;
-			}) =>
-				renderComponent(DynamicTableCell, {
-					row: row,
-					column: column,
-					uiSchemas: uiSchemas
-				}),
-			accessorKey: 'Age'
 		},
 		{
 			id: 'Containers',
@@ -234,6 +214,27 @@ function getStatefulSetColumnDefinitions(
 			meta: {
 				class: 'hidden xl:table-cell'
 			}
+		},
+		{
+			id: 'Age',
+			header: ({ column }: { column: Column<Record<StatefulSetAttribute, JsonValue>> }) =>
+				renderComponent(DynamicTableHeader, {
+					column: column,
+					dataSchemas: dataSchemas
+				}),
+			cell: ({
+				column,
+				row
+			}: {
+				column: Column<Record<StatefulSetAttribute, JsonValue>>;
+				row: Row<Record<StatefulSetAttribute, JsonValue>>;
+			}) =>
+				renderComponent(DynamicTableCell, {
+					row: row,
+					column: column,
+					uiSchemas: uiSchemas
+				}),
+			accessorKey: 'Age'
 		}
 	];
 }

--- a/src/lib/components/kind-viewer/kind-viewers/task.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/task.ts
@@ -136,7 +136,8 @@ function getTaskColumnDefinitions(
 					column: column,
 					uiSchemas: uiSchemas
 				}),
-			accessorKey: 'Namespace'
+			accessorKey: 'Namespace',
+			meta: { defaultHidden: true }
 		},
 		{
 			id: 'State',

--- a/src/lib/components/kind-viewer/kind-viewers/virtualmachine.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/virtualmachine.ts
@@ -148,7 +148,8 @@ function getVirtualMachineColumnDefinitions(
 					column,
 					uiSchemas
 				}),
-			accessorKey: 'Namespace'
+			accessorKey: 'Namespace',
+			meta: { defaultHidden: true }
 		},
 		simpleColumn('Status'),
 		simpleColumn('Ready'),

--- a/src/lib/components/kind-viewer/kind-viewers/workspaces.ts
+++ b/src/lib/components/kind-viewer/kind-viewers/workspaces.ts
@@ -139,7 +139,8 @@ function getWorkspaceColumnDefinitions(
 					column: column,
 					uiSchemas: uiSchemas
 				}),
-			accessorKey: 'Namespace'
+			accessorKey: 'Namespace',
+			meta: { defaultHidden: true }
 		},
 		{
 			id: 'Admin',


### PR DESCRIPTION
…iewers

- Add defaultHidden meta support to dynamic-table, initializing column visibility from column definition meta at mount time
- Set Namespace column to defaultHidden: true across all 31 kind-viewers
- Hide secondary columns by default in DaemonSet (Up-To-Date, Available) and CronJob (Time Zone, Creation Timestamp) to prevent table overflow
- Move Age / Creation Timestamp to the rightmost position in all workload tables (Deployment, StatefulSet, DaemonSet, CronJob, Job, Pod) and reorder remaining columns by importance