### PR TITLE
feat(cluster-analytics): label namespace rankings with owning workspace

### DIFF
--- a/src/lib/components/custom/top-bar-list/index.ts
+++ b/src/lib/components/custom/top-bar-list/index.ts
@@ -1,3 +1,4 @@
 import { default as TopBarList } from './top-bar-list.svelte';
 
 export { TopBarList as Root, TopBarList };
+export type { TopBar } from './types';

--- a/src/lib/components/custom/top-bar-list/top-bar-list.svelte
+++ b/src/lib/components/custom/top-bar-list/top-bar-list.svelte
@@ -13,18 +13,7 @@
 	import { m } from '$lib/paraglide/messages';
 	import { cn } from '$lib/utils';
 
-	type Bar = {
-		label: string;
-		value: number;
-		displayValue: string;
-		barClass?: string;
-		textClass?: string;
-		// Click payload / list key; defaults to `label` when omitted. Lets a bar display a
-		// human-friendly name while clicking through a distinct identity token.
-		id?: string;
-		// Optional short tag shown next to the label (e.g. to mark a standalone model).
-		badge?: string;
-	};
+	import type { TopBar } from './types';
 
 	let {
 		title,
@@ -38,7 +27,7 @@
 		title: string;
 		description: string;
 		tooltip: string;
-		bars: Bar[];
+		bars: TopBar[];
 		isLoaded: boolean;
 		onBarClick?: (label: string) => void;
 		// When true, the list lives in a fixed-height scroll area with a maximize button — so
@@ -50,7 +39,7 @@
 	const maxValue = $derived(bars.reduce((m, b) => Math.max(m, b.value), 0));
 </script>
 
-{#snippet barContent(bar: Bar)}
+{#snippet barContent(bar: TopBar)}
 	{@const pct = maxValue > 0 ? Math.max(2, (bar.value / maxValue) * 100) : 0}
 	<span class="flex flex-col gap-1 overflow-hidden">
 		<span class="flex items-center gap-1.5 overflow-hidden">

--- a/src/lib/components/custom/top-bar-list/types.ts
+++ b/src/lib/components/custom/top-bar-list/types.ts
@@ -1,0 +1,14 @@
+/** A single bar in a {@link TopBarList}. The component is category-agnostic: callers
+ * (model, namespace, node, …) decide what each field means. */
+export type TopBar = {
+	label: string;
+	value: number;
+	displayValue: string;
+	barClass?: string;
+	textClass?: string;
+	// Click payload / list key; defaults to `label` when omitted. Lets a bar display a
+	// human-friendly name while clicking through a distinct identity token.
+	id?: string;
+	// Optional short tag shown next to the label (e.g. to mark a standalone model).
+	badge?: string;
+};

--- a/src/lib/components/dashboard/cluster/analytics/index.svelte
+++ b/src/lib/components/dashboard/cluster/analytics/index.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
+	import { createClient, type Transport } from '@connectrpc/connect';
+	import { ResourceService } from '@otterscale/api/resource/v1';
 	import { PrometheusDriver } from 'prometheus-query';
-	import { onMount } from 'svelte';
+	import { getContext, onMount } from 'svelte';
 
+	import { page } from '$app/state';
 	import { m } from '$lib/paraglide/messages';
 
 	import NamespaceCommitment from './namespace/namespace-commitment.svelte';
@@ -36,7 +39,39 @@
 		isReloading?: boolean;
 	} = $props();
 
+	const transport = getContext<Transport>('transport');
+	const resourceClient = createClient(ResourceService, transport);
+
 	const reloading = $derived(isReloading ?? false);
+
+	// namespace → workspace name (Workspace CRD owns one namespace via `spec.namespace`); lets the
+	// Section-A ranking bars show the owning workspace instead of the raw namespace.
+	let namespaceToWorkspace = $state<Record<string, string>>({});
+	async function fetchWorkspaceMap() {
+		try {
+			const response = await resourceClient.list({
+				cluster: page.params.cluster ?? '',
+				group: 'tenant.otterscale.io',
+				version: 'v1alpha1',
+				resource: 'workspaces',
+				namespace: ''
+			});
+			const map: Record<string, string> = {};
+			for (const item of response.items) {
+				const obj = item.object as Record<string, unknown> | undefined;
+				const meta = obj?.metadata as Record<string, unknown> | undefined;
+				const spec = obj?.spec as Record<string, unknown> | undefined;
+				const name = meta?.name;
+				const ns = spec?.namespace;
+				if (typeof name === 'string' && typeof ns === 'string' && name && ns) {
+					map[ns] = name;
+				}
+			}
+			namespaceToWorkspace = map;
+		} catch (error) {
+			console.error('Failed to list workspaces:', error);
+		}
+	}
 	// `.*` is the "all" sentinel selected by default in the pickers; treat it as "nothing
 	// drilled in" so Section B shows its placeholder until a concrete node / namespace is picked.
 	const hasNodeSelected = $derived(!!selectedNode && selectedNode !== '.*');
@@ -51,6 +86,7 @@
 	// commitment + pods cards resolve the selected instance back to its node name.
 	let instanceToNode = $state<Record<string, string>>({});
 	onMount(async () => {
+		fetchWorkspaceMap();
 		try {
 			const response = await client.instantQuery('node_uname_info');
 			const series = (response.result ?? []) as { metric: { labels: Record<string, string> } }[];
@@ -162,6 +198,7 @@
 					description={m.namespace_cpu_usage_description()}
 					tooltip={m.namespace_cpu_usage_tooltip()}
 					onNamespaceClick={handleNamespaceClick}
+					{namespaceToWorkspace}
 					isReloading={reloading}
 				/>
 				<NamespaceRanking
@@ -171,6 +208,7 @@
 					description={m.namespace_memory_usage_description()}
 					tooltip={m.namespace_memory_usage_tooltip()}
 					onNamespaceClick={handleNamespaceClick}
+					{namespaceToWorkspace}
 					isReloading={reloading}
 				/>
 				<NamespaceRanking
@@ -180,6 +218,7 @@
 					description={m.namespace_pod_count_description()}
 					tooltip={m.namespace_pod_count_tooltip()}
 					onNamespaceClick={handleNamespaceClick}
+					{namespaceToWorkspace}
 					isReloading={reloading}
 				/>
 				<NamespaceRanking
@@ -189,6 +228,7 @@
 					description={m.namespace_restart_count_description()}
 					tooltip={m.namespace_restart_count_tooltip()}
 					onNamespaceClick={handleNamespaceClick}
+					{namespaceToWorkspace}
 					isReloading={reloading}
 				/>
 			</div>

--- a/src/lib/components/dashboard/cluster/analytics/namespace/namespace-ranking.svelte
+++ b/src/lib/components/dashboard/cluster/analytics/namespace/namespace-ranking.svelte
@@ -5,6 +5,7 @@
 	import { ReloadManager } from '$lib/components/custom/reloader';
 	import { TopBarList } from '$lib/components/custom/top-bar-list';
 	import { formatCapacity } from '$lib/formatter';
+	import { m } from '$lib/paraglide/messages';
 	import { classifyThreshold, type ThresholdLevel } from '$lib/prometheus';
 
 	// Reusable "top namespaces" ranking. `kind="cpu"` ranks by live CPU cores;
@@ -18,6 +19,7 @@
 		description,
 		tooltip,
 		onNamespaceClick,
+		namespaceToWorkspace = {},
 		isReloading = $bindable()
 	}: {
 		prometheusDriver: PrometheusDriver;
@@ -26,6 +28,8 @@
 		description: string;
 		tooltip: string;
 		onNamespaceClick?: (namespace: string) => void;
+		// namespace → workspace name; bars display the workspace, falling back to the namespace.
+		namespaceToWorkspace?: Record<string, string>;
 		isReloading?: boolean;
 	} = $props();
 
@@ -63,15 +67,34 @@
 		};
 	}
 
-	type Bar = {
-		label: string;
+	// Raw rows keep the namespace; the displayed label is resolved at render so bars relabel
+	// reactively if the workspace map arrives after the first fetch.
+	type RawBar = {
+		namespace: string;
 		value: number;
 		displayValue: string;
 		barClass?: string;
 		textClass?: string;
 	};
-	let bars = $state<Bar[]>([]);
+	let rawBars = $state<RawBar[]>([]);
 	let isLoaded = $state(false);
+
+	// label = workspace name (fallback: namespace); id = namespace (click payload for drill-in).
+	// Bars resolved to a workspace get a "Workspace" badge, like the standalone-model tag.
+	const bars = $derived(
+		rawBars.map((b) => {
+			const workspace = namespaceToWorkspace[b.namespace];
+			return {
+				label: workspace || b.namespace,
+				id: b.namespace,
+				badge: workspace ? m.workspace() : undefined,
+				value: b.value,
+				displayValue: b.displayValue,
+				barClass: b.barClass,
+				textClass: b.textClass
+			};
+		})
+	);
 
 	async function fetch() {
 		try {
@@ -80,15 +103,15 @@
 				metric: { labels: Record<string, string> };
 				value?: { value: unknown };
 			}[];
-			bars = series
+			rawBars = series
 				.map((s) => {
 					const namespace = s.metric?.labels?.namespace ?? '';
 					const value = Number(s.value?.value);
 					return namespace && Number.isFinite(value)
-						? { label: namespace, value, displayValue: displayValue(value), ...classes(value) }
+						? { namespace, value, displayValue: displayValue(value), ...classes(value) }
 						: null;
 				})
-				.filter((b): b is Bar => b !== null)
+				.filter((b): b is RawBar => b !== null)
 				.sort((a, b) => b.value - a.value);
 		} catch (error) {
 			console.error('Failed to fetch namespace ranking:', error);

--- a/src/lib/components/dashboard/cluster/analytics/namespace/pvc-storage.svelte
+++ b/src/lib/components/dashboard/cluster/analytics/namespace/pvc-storage.svelte
@@ -3,7 +3,7 @@
 	import { onDestroy, onMount } from 'svelte';
 
 	import { ReloadManager } from '$lib/components/custom/reloader';
-	import { TopBarList } from '$lib/components/custom/top-bar-list';
+	import { type TopBar, TopBarList } from '$lib/components/custom/top-bar-list';
 	import { formatCapacity } from '$lib/formatter';
 	import { m } from '$lib/paraglide/messages';
 	import {
@@ -28,14 +28,7 @@
 		return ns && ns !== '.*' ? `{namespace="${escapePromqlStringLiteral(ns)}"}` : '';
 	});
 
-	type Bar = {
-		label: string;
-		value: number;
-		displayValue: string;
-		barClass?: string;
-		textClass?: string;
-	};
-	let bars = $state<Bar[]>([]);
+	let bars = $state<TopBar[]>([]);
 	let isLoaded = $state(false);
 
 	function barClass(level: ThresholdLevel): string {

--- a/src/lib/components/dashboard/cluster/analytics/node/node-pressure.svelte
+++ b/src/lib/components/dashboard/cluster/analytics/node/node-pressure.svelte
@@ -3,7 +3,7 @@
 	import { onDestroy, onMount } from 'svelte';
 
 	import { ReloadManager } from '$lib/components/custom/reloader';
-	import { TopBarList } from '$lib/components/custom/top-bar-list';
+	import { type TopBar, TopBarList } from '$lib/components/custom/top-bar-list';
 	import { classifyThreshold, fetchCombinedInstant, type ThresholdLevel } from '$lib/prometheus';
 
 	// Reusable node-pressure ranking: one bar per node, sized by Request%, labelled with the
@@ -35,14 +35,7 @@
 		lim: `100 * sum(kube_pod_container_resource_limits{resource="${resource}", unit="${unit}"}) by (node) / ${alloc}`
 	});
 
-	type Bar = {
-		label: string;
-		value: number;
-		displayValue: string;
-		barClass?: string;
-		textClass?: string;
-	};
-	let bars = $state<Bar[]>([]);
+	let bars = $state<TopBar[]>([]);
 	let isLoaded = $state(false);
 
 	function barClass(level: ThresholdLevel): string {

--- a/src/lib/components/dashboard/cluster/analytics/node/node-ranking.svelte
+++ b/src/lib/components/dashboard/cluster/analytics/node/node-ranking.svelte
@@ -3,7 +3,7 @@
 	import { onDestroy, onMount } from 'svelte';
 
 	import { ReloadManager } from '$lib/components/custom/reloader';
-	import { TopBarList } from '$lib/components/custom/top-bar-list';
+	import { type TopBar, TopBarList } from '$lib/components/custom/top-bar-list';
 	import { classifyThreshold, type ThresholdLevel } from '$lib/prometheus';
 
 	// Single-value node rankings complementing the CPU/Memory pressure cards. `pods` and
@@ -41,14 +41,7 @@
 	});
 	const labelKey = $derived(kind === 'gpu' ? 'Hostname' : 'node');
 
-	type Bar = {
-		label: string;
-		value: number;
-		displayValue: string;
-		barClass?: string;
-		textClass?: string;
-	};
-	let bars = $state<Bar[]>([]);
+	let bars = $state<TopBar[]>([]);
 	let isLoaded = $state(false);
 
 	function displayValue(value: number): string {
@@ -87,7 +80,7 @@
 						? { label: node, value, displayValue: displayValue(value), ...classes(value) }
 						: null;
 				})
-				.filter((b): b is Bar => b !== null)
+				.filter((b): b is TopBar => b !== null)
 				.sort((a, b) => b.value - a.value);
 		} catch (error) {
 			console.error('Failed to fetch node ranking:', error);

--- a/src/lib/components/dashboard/model/analytics/a-top-kv-pressure.svelte
+++ b/src/lib/components/dashboard/model/analytics/a-top-kv-pressure.svelte
@@ -3,7 +3,7 @@
 	import { onDestroy, onMount } from 'svelte';
 
 	import { ReloadManager } from '$lib/components/custom/reloader';
-	import { TopBarList } from '$lib/components/custom/top-bar-list';
+	import { type TopBar, TopBarList } from '$lib/components/custom/top-bar-list';
 	import { m } from '$lib/paraglide/messages';
 	import {
 		classifyThreshold,
@@ -25,17 +25,7 @@
 		onModelClick?: (model: string) => void;
 	} = $props();
 
-	type Bar = {
-		label: string;
-		value: number;
-		displayValue: string;
-		barClass?: string;
-		textClass?: string;
-		id?: string;
-		badge?: string;
-	};
-
-	let bars = $state<Bar[]>([]);
+	let bars = $state<TopBar[]>([]);
 	let isLoaded = $state(false);
 
 	function buildQuery(): string {

--- a/src/lib/components/dashboard/model/analytics/a-top-p99-latency.svelte
+++ b/src/lib/components/dashboard/model/analytics/a-top-p99-latency.svelte
@@ -3,7 +3,7 @@
 	import { onDestroy, onMount } from 'svelte';
 
 	import { ReloadManager } from '$lib/components/custom/reloader';
-	import { TopBarList } from '$lib/components/custom/top-bar-list';
+	import { type TopBar, TopBarList } from '$lib/components/custom/top-bar-list';
 	import { formatLatency } from '$lib/formatter';
 	import { m } from '$lib/paraglide/messages';
 	import {
@@ -25,9 +25,7 @@
 		onModelClick?: (model: string) => void;
 	} = $props();
 
-	type Bar = { label: string; value: number; displayValue: string; id?: string; badge?: string };
-
-	let bars = $state<Bar[]>([]);
+	let bars = $state<TopBar[]>([]);
 	let isLoaded = $state(false);
 
 	function buildQuery(): string {

--- a/src/lib/components/dashboard/model/analytics/a-top-throughput.svelte
+++ b/src/lib/components/dashboard/model/analytics/a-top-throughput.svelte
@@ -3,7 +3,7 @@
 	import { onDestroy, onMount } from 'svelte';
 
 	import { ReloadManager } from '$lib/components/custom/reloader';
-	import { TopBarList } from '$lib/components/custom/top-bar-list';
+	import { type TopBar, TopBarList } from '$lib/components/custom/top-bar-list';
 	import { m } from '$lib/paraglide/messages';
 	import {
 		escapePromqlStringLiteral,
@@ -24,9 +24,7 @@
 		onModelClick?: (model: string) => void;
 	} = $props();
 
-	type Bar = { label: string; value: number; displayValue: string; id?: string; badge?: string };
-
-	let bars = $state<Bar[]>([]);
+	let bars = $state<TopBar[]>([]);
 	let isLoaded = $state(false);
 
 	function buildQuery(): string {


### PR DESCRIPTION
Resolve each namespace to its owning Workspace (via the Workspace CRD's spec.namespace) and display the workspace name with a "Workspace" badge in the Section-A namespace ranking bars, falling back to the raw namespace. Labels resolve at render time so bars relabel reactively once the namespace→workspace map arrives.

Extract the duplicated bar type into a shared, exported `TopBar` type (top-bar-list/types.ts) and reuse it across the cluster and model analytics ranking components, removing the per-file copies.