### PR TITLE
feat: enhance sidebar with tabbed navigation and support button (#557)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -510,6 +510,7 @@
 	"schedule": "Schedule",
 	"previous": "Previous",
 	"submit": "Submit",
+	"support": "Support",
 	"import_cluster_info_title": "Cluster Information",
 	"import_cluster_info_description": "Provide details about this cluster.",
 	"import_cluster_name_label": "Cluster Name",

--- a/messages/zh-hant.json
+++ b/messages/zh-hant.json
@@ -510,6 +510,7 @@
 	"schedule": "排程器",
 	"previous": "上一步",
 	"submit": "送出",
+	"support": "支援",
 	"import_cluster_info_title": "叢集資訊",
 	"import_cluster_info_description": "請提供此叢集的相關資訊。",
 	"import_cluster_name_label": "叢集名稱",

--- a/src/lib/components/layout/nav-main.svelte
+++ b/src/lib/components/layout/nav-main.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
 	import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
+	import LayersIcon from '@lucide/svelte/icons/layers';
+	import SquareTerminalIcon from '@lucide/svelte/icons/square-terminal';
 	import type { Component } from 'svelte';
 
+	import { page } from '$app/state';
 	import * as Collapsible from '$lib/components/ui/collapsible';
 	import * as Sidebar from '$lib/components/ui/sidebar';
+	import * as Tabs from '$lib/components/ui/tabs';
 
 	type NavItem = {
 		title: string;
@@ -29,27 +33,55 @@
 		kubernetesItems: NavItem[];
 	} = $props();
 
+	function matchesCurrentUrl(items: NavItem[]): boolean {
+		const current = page.url.pathname + page.url.search;
+		return items.some(
+			(item) => item.url === current || item.items?.some((subItem) => subItem.url === current)
+		);
+	}
+
 	let activeIndex = $state(0);
 
-	const currentLabel = $derived(activeIndex === 0 ? platformLabel : kubernetesLabel);
-	const currentItems = $derived(activeIndex === 0 ? platformItems : kubernetesItems);
+	$effect(() => {
+		if (matchesCurrentUrl(kubernetesItems)) {
+			activeIndex = 1;
+		} else if (matchesCurrentUrl(platformItems)) {
+			activeIndex = 0;
+		}
+	});
 
-	function toggleLabel() {
-		activeIndex = 1 - activeIndex;
-	}
+	const views = $derived([
+		{ label: platformLabel, icon: LayersIcon, items: platformItems },
+		{ label: kubernetesLabel, icon: SquareTerminalIcon, items: kubernetesItems }
+	]);
+	const currentView = $derived(views[activeIndex]);
+	const currentUrl = $derived(page.url.pathname + page.url.search);
 </script>
 
 <Sidebar.Group>
-	<Sidebar.GroupLabel
-		onclick={toggleLabel}
-		class="w-full cursor-pointer outline-none hover:underline focus-visible:ring-2 focus-visible:ring-sidebar-ring"
+	<Tabs.Root
+		value={String(activeIndex)}
+		onValueChange={(value) => (activeIndex = Number(value))}
+		class="group-data-[collapsible=icon]:hidden"
 	>
-		{currentLabel}
-	</Sidebar.GroupLabel>
+		<Tabs.List class="w-full">
+			{#each views as view, index (index)}
+				<Tabs.Trigger value={String(index)}>
+					{view.label}
+				</Tabs.Trigger>
+			{/each}
+		</Tabs.List>
+	</Tabs.Root>
+</Sidebar.Group>
+
+<Sidebar.Group>
 	<Sidebar.Menu>
-		{#each currentItems as item (item.title)}
+		{#each currentView.items as item (item.title)}
 			{#if item.items && item.items.length > 0}
-				<Collapsible.Root open={item.isActive} class="group/collapsible">
+				<Collapsible.Root
+					open={item.isActive || item.items.some((subItem) => subItem.url === currentUrl)}
+					class="group/collapsible"
+				>
 					{#snippet child({ props })}
 						<Sidebar.MenuItem {...props}>
 							<Collapsible.Trigger>
@@ -69,10 +101,13 @@
 								<Sidebar.MenuSub>
 									{#each item.items as subItem (subItem.title)}
 										<Sidebar.MenuSubItem>
-											<Sidebar.MenuSubButton aria-disabled={subItem.disabled}>
+											<Sidebar.MenuSubButton
+												isActive={subItem.url === currentUrl}
+												aria-disabled={subItem.disabled}
+											>
 												{#snippet child({ props })}
 													<!-- eslint-disable svelte/no-navigation-without-resolve -->
-													<a href={subItem.url} {...props}>
+													<a href={subItem.disabled ? undefined : subItem.url} {...props}>
 														<span>{subItem.title}</span>
 													</a>
 													<!-- eslint-enable svelte/no-navigation-without-resolve -->
@@ -87,7 +122,7 @@
 				</Collapsible.Root>
 			{:else}
 				<Sidebar.MenuItem>
-					<Sidebar.MenuButton tooltipContent={item.title}>
+					<Sidebar.MenuButton isActive={item.url === currentUrl} tooltipContent={item.title}>
 						{#snippet child({ props })}
 							<!-- eslint-disable svelte/no-navigation-without-resolve -->
 							<a href={item.url} {...props}>

--- a/src/lib/components/layout/nav-secondary.svelte
+++ b/src/lib/components/layout/nav-secondary.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import BookOpenIcon from '@lucide/svelte/icons/book-open';
+	import LifeBuoyIcon from '@lucide/svelte/icons/life-buoy';
 	import PackageIcon from '@lucide/svelte/icons/package';
 	import type { ComponentProps } from 'svelte';
 
@@ -21,21 +21,21 @@
 	<Sidebar.GroupContent>
 		<Sidebar.Menu>
 			<Sidebar.MenuItem>
-				<Sidebar.MenuButton size="sm" tooltipContent={m.documentation()} class="[&>svg]:size-3.5">
+				<Sidebar.MenuButton size="sm" tooltipContent={m.support()}>
 					{#snippet child({ props })}
-						<a href="https://otterscale.io" target="_blank" {...props}>
-							<BookOpenIcon />
-							<span>{m.documentation()}</span>
-						</a>
+						<button type="button" {...props} onclick={() => (open = true)}>
+							<LifeBuoyIcon />
+							<span>{m.support()}</span>
+						</button>
 					{/snippet}
 				</Sidebar.MenuButton>
 			</Sidebar.MenuItem>
 			{#if harborUrl}
 				<Sidebar.MenuItem>
-					<Sidebar.MenuButton size="sm" tooltipContent={m.registry()} class="[&>svg]:size-3.5">
+					<Sidebar.MenuButton size="sm" tooltipContent={m.registry()}>
 						{#snippet child({ props })}
 							<!-- eslint-disable svelte/no-navigation-without-resolve -->
-							<a href={harborUrl} target="_blank" {...props}>
+							<a href={harborUrl} target="_blank" rel="noopener noreferrer" {...props}>
 								<PackageIcon />
 								<span>{m.registry()}</span>
 							</a>

--- a/src/routes/(auth)/+layout.svelte
+++ b/src/routes/(auth)/+layout.svelte
@@ -12,7 +12,6 @@
 	import FileTextIcon from '@lucide/svelte/icons/file-text';
 	import GaugeIcon from '@lucide/svelte/icons/gauge';
 	import HardDriveIcon from '@lucide/svelte/icons/hard-drive';
-	import InfoIcon from '@lucide/svelte/icons/info';
 	import LayersIcon from '@lucide/svelte/icons/layers';
 	import LayoutGridIcon from '@lucide/svelte/icons/layout-grid';
 	import NetworkIcon from '@lucide/svelte/icons/network';
@@ -28,7 +27,6 @@
 	import { page } from '$app/state';
 	import { env } from '$env/dynamic/public';
 	import {
-		DialogAbout,
 		NavMain,
 		NavSecondary,
 		NavUser,
@@ -70,7 +68,6 @@
 	let workspaces = $state<TenantOtterscaleIoV1Alpha1Workspace[]>([]);
 
 	let sidebarOpen = $state(true);
-	let aboutOpen = $state(false);
 	let importOpen = $state(false);
 
 	async function fetchClusters(signal?: AbortSignal): Promise<Link[]> {
@@ -702,7 +699,6 @@
 	<title>{current ? `${current.title} - OtterScale` : 'OtterScale'}</title>
 </svelte:head>
 
-<DialogAbout bind:open={aboutOpen} />
 <Sidebar.Provider class="h-svh overflow-hidden" bind:open={sidebarOpen}>
 	<Sidebar.Root id="sidebar-guide-step" collapsible="icon" variant="inset" class="p-3">
 		{#if activeCluster && isMounted}
@@ -714,7 +710,7 @@
 					workspace={page.params.workspace}
 				/>
 			</Sidebar.Header>
-			<Sidebar.Content class="gap-2">
+			<Sidebar.Content class="gap-0">
 				{#if page.params.workspace}
 					<NavMain
 						platformLabel={m.platform()}
@@ -765,23 +761,6 @@
 				</Breadcrumb.Root>
 			</div>
 			<div class="flex items-center gap-2 px-4">
-				<Tooltip.Root>
-					<Tooltip.Trigger>
-						{#snippet child({ props })}
-							<Button
-								{...props}
-								variant="ghost"
-								size="icon"
-								class="size-7"
-								onclick={() => (aboutOpen = true)}
-							>
-								<InfoIcon />
-								<span class="sr-only">About</span>
-							</Button>
-						{/snippet}
-					</Tooltip.Trigger>
-					<Tooltip.Content>About OtterScale</Tooltip.Content>
-				</Tooltip.Root>
 				<Tooltip.Root>
 					<Tooltip.Trigger>
 						{#snippet child({ props })}


### PR DESCRIPTION
* feat: add support label to English and Traditional Chinese messages; remove unused InfoIcon and DialogAbout component

* feat: replace documentation link with support button in sidebar

* feat: enhance sidebar navigation with tabs and active state management

* fix: add missing newline at end of JSON files for en and zh-hant messages

(cherry picked from commit c186229b8f8a1dce3a112776d1dc7eab180a4cb1)