### PR TITLE
feat: unify kind-viewer action dialogs and enhance log/view/vnc actions

### DIFF
--- a/src/lib/components/applications/vnc/vnc-viewer.svelte
+++ b/src/lib/components/applications/vnc/vnc-viewer.svelte
@@ -8,11 +8,13 @@
 	let {
 		cluster,
 		namespace,
-		name
+		name,
+		onConnectionChange
 	}: {
 		cluster: string;
 		namespace: string;
 		name: string;
+		onConnectionChange?: (connected: boolean) => void;
 	} = $props();
 
 	const transport: Transport = getContext('transport');
@@ -42,10 +44,12 @@
 			rfb.addEventListener('connect', () => {
 				isConnected = true;
 				error = '';
+				onConnectionChange?.(true);
 			});
 
 			rfb.addEventListener('disconnect', (e) => {
 				isConnected = false;
+				onConnectionChange?.(false);
 				if (!(e as CustomEvent<{ clean: boolean }>).detail.clean) {
 					error = 'VNC connection lost';
 				}
@@ -53,6 +57,7 @@
 		} catch (err) {
 			error = `Failed to connect: ${err}`;
 			isConnected = false;
+			onConnectionChange?.(false);
 		}
 	}
 
@@ -61,6 +66,7 @@
 		rfb = null;
 		ws = null;
 		isConnected = false;
+		onConnectionChange?.(false);
 	}
 
 	onMount(() => {

--- a/src/lib/components/kind-viewer/kind-viewer-actions/default/constants.ts
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/default/constants.ts
@@ -1,0 +1,6 @@
+// Shared Dialog.Content sizing so every kind-viewer action opens with the same frame.
+export const ACTION_DIALOG_CONTENT_CLASS = 'flex h-[85vh] max-w-[70vw] min-w-[55vw] flex-col gap-3';
+
+// Same frame width, but height hugs the content — for landscape content like Terminal and VNC.
+export const ACTION_DIALOG_CONTENT_FIT_CLASS =
+	'flex h-fit max-h-[85vh] max-w-[70vw] min-w-[55vw] flex-col gap-3';

--- a/src/lib/components/kind-viewer/kind-viewer-actions/default/describe.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/default/describe.svelte
@@ -1,15 +1,23 @@
 <script lang="ts">
 	import { ConnectError, createClient, type Transport } from '@connectrpc/connect';
+	import CheckIcon from '@lucide/svelte/icons/check';
+	import CircleAlertIcon from '@lucide/svelte/icons/circle-alert';
+	import CopyIcon from '@lucide/svelte/icons/copy';
 	import FileJsonIcon from '@lucide/svelte/icons/file-json';
 	import FileSearchIcon from '@lucide/svelte/icons/file-search';
 	import { ResourceService } from '@otterscale/api/resource/v1';
 	import { getContext, type Snippet } from 'svelte';
 
-	import Button from '$lib/components/ui/button/button.svelte';
+	import * as Alert from '$lib/components/ui/alert';
+	import { Button } from '$lib/components/ui/button';
 	import * as Dialog from '$lib/components/ui/dialog';
+	import * as Empty from '$lib/components/ui/empty';
 	import * as Item from '$lib/components/ui/item';
+	import { Spinner } from '$lib/components/ui/spinner';
 	import * as Tabs from '$lib/components/ui/tabs/index.js';
+	import * as Tooltip from '$lib/components/ui/tooltip';
 
+	import { ACTION_DIALOG_CONTENT_CLASS } from './constants';
 	import { formatDescribe } from './describe-formatter';
 
 	let {
@@ -74,10 +82,20 @@
 			);
 		} catch (err) {
 			console.error(`Failed to describe ${name}:`, err);
-			error = `Failed to describe ${name}: ${(err as ConnectError).message}`;
+			error = (err as ConnectError).message;
 		} finally {
 			isLoading = false;
 		}
+	}
+
+	let copied = $state(false);
+
+	async function copyContent() {
+		const text = mode === 'json' ? jsonText : describeText;
+		if (!text) return;
+		await navigator.clipboard.writeText(text);
+		copied = true;
+		setTimeout(() => (copied = false), 1500);
 	}
 
 	function handleOpenChange(isOpen: boolean) {
@@ -102,70 +120,108 @@
 			</Item.Root>
 		</Dialog.Trigger>
 	{/if}
-	<Dialog.Content class="flex h-fit max-h-[90vh] max-w-[70vw] min-w-[55vw] flex-col gap-3">
+	<Dialog.Content class={ACTION_DIALOG_CONTENT_CLASS}>
 		<Dialog.Header>
 			<div class="flex items-end justify-between gap-4">
-				<Item.Root class="p-0">
-					<Item.Content class="text-left">
-						<Item.Title class="text-lg font-bold">
-							Describe — {name}
-						</Item.Title>
-						<Item.Description>
-							{#if namespace}
-								Resource details and events in namespace <strong>{namespace}</strong>
-							{:else}
-								Resource details and events
-							{/if}
-						</Item.Description>
-					</Item.Content>
-				</Item.Root>
-
-				<div class="flex gap-1">
-					<Button
-						size="icon-sm"
-						variant="ghost"
-						disabled={mode === 'describe'}
-						onclick={() => (mode = 'describe')}
-					>
-						<FileSearchIcon />
-					</Button>
-					<Button
-						size="icon-sm"
-						variant="ghost"
-						disabled={mode === 'json'}
-						onclick={() => (mode = 'json')}
-					>
-						<FileJsonIcon />
-					</Button>
+				<div class="flex flex-col gap-1.5 text-left">
+					<Dialog.Title class="text-lg font-bold">Describe — {name}</Dialog.Title>
+					<Dialog.Description>
+						{#if namespace}
+							Resource details and events in namespace <strong>{namespace}</strong>
+						{:else}
+							Resource details and events
+						{/if}
+					</Dialog.Description>
+				</div>
+				<!-- -mr-2 lines the icon column up with the dialog's close button (right-4 vs p-6). -->
+				<div class="-mr-2 flex shrink-0 items-center gap-1">
+					<Tooltip.Root ignoreNonKeyboardFocus>
+						<Tooltip.Trigger>
+							{#snippet child({ props })}
+								<Button
+									{...props}
+									size="icon-sm"
+									variant="ghost"
+									disabled={mode === 'describe'}
+									onclick={() => (mode = 'describe')}
+									aria-label="Describe view"
+								>
+									<FileSearchIcon />
+								</Button>
+							{/snippet}
+						</Tooltip.Trigger>
+						<Tooltip.Content>Describe view</Tooltip.Content>
+					</Tooltip.Root>
+					<Tooltip.Root ignoreNonKeyboardFocus>
+						<Tooltip.Trigger>
+							{#snippet child({ props })}
+								<Button
+									{...props}
+									size="icon-sm"
+									variant="ghost"
+									disabled={mode === 'json'}
+									onclick={() => (mode = 'json')}
+									aria-label="JSON view"
+								>
+									<FileJsonIcon />
+								</Button>
+							{/snippet}
+						</Tooltip.Trigger>
+						<Tooltip.Content>JSON view</Tooltip.Content>
+					</Tooltip.Root>
+					<Tooltip.Root ignoreNonKeyboardFocus>
+						<Tooltip.Trigger>
+							{#snippet child({ props })}
+								<Button
+									{...props}
+									size="icon-sm"
+									variant="ghost"
+									disabled={isLoading || !!error}
+									onclick={copyContent}
+									aria-label="Copy to clipboard"
+								>
+									{#if copied}
+										<CheckIcon />
+									{:else}
+										<CopyIcon />
+									{/if}
+								</Button>
+							{/snippet}
+						</Tooltip.Trigger>
+						<Tooltip.Content>{copied ? 'Copied!' : 'Copy to clipboard'}</Tooltip.Content>
+					</Tooltip.Root>
 				</div>
 			</div>
 		</Dialog.Header>
 
-		<div class="flex-1 overflow-auto">
+		<Tabs.Root bind:value={mode} class="flex min-h-0 flex-1 flex-col gap-3">
 			{#if isLoading}
-				<div
-					class="flex h-[60vh] items-center justify-center rounded-md border bg-muted text-xs text-muted-foreground"
-				>
-					Loading...
+				<div class="min-h-0 flex-1 rounded-md border bg-muted">
+					<Empty.Root class="h-full">
+						<Empty.Header>
+							<Empty.Media variant="icon">
+								<Spinner />
+							</Empty.Media>
+							<Empty.Title>Loading resource details</Empty.Title>
+						</Empty.Header>
+					</Empty.Root>
 				</div>
 			{:else if error}
-				<div
-					class="flex h-[60vh] items-center justify-center rounded-md border bg-muted text-xs text-destructive"
-				>
-					{error}
-				</div>
+				<Alert.Root variant="destructive">
+					<CircleAlertIcon />
+					<Alert.Title>Failed to describe {name}</Alert.Title>
+					<Alert.Description>{error}</Alert.Description>
+				</Alert.Root>
 			{:else}
-				<Tabs.Root bind:value={mode} class="flex h-full flex-col">
-					<Tabs.Content value="describe" class="mt-0 outline-none">
-						<pre
-							class="max-h-[70vh] w-full overflow-auto rounded-md border bg-muted p-4 font-mono text-[11px] leading-relaxed whitespace-pre text-foreground">{describeText}</pre>
-					</Tabs.Content>
-					<Tabs.Content value="json" class="mt-0 outline-none">
-						<pre
-							class="max-h-[70vh] w-full overflow-auto rounded-md border bg-muted p-4 font-mono text-[11px] leading-relaxed whitespace-pre text-foreground">{jsonText}</pre>
-					</Tabs.Content>
-				</Tabs.Root>
+				<Tabs.Content value="describe" class="mt-0 min-h-0 flex-1 outline-none">
+					<pre
+						class="h-full w-full overflow-auto rounded-md border bg-muted p-4 font-mono text-xs leading-relaxed whitespace-pre text-foreground">{describeText}</pre>
+				</Tabs.Content>
+				<Tabs.Content value="json" class="mt-0 min-h-0 flex-1 outline-none">
+					<pre
+						class="h-full w-full overflow-auto rounded-md border bg-muted p-4 font-mono text-xs leading-relaxed whitespace-pre text-foreground">{jsonText}</pre>
+				</Tabs.Content>
 			{/if}
-		</div>
+		</Tabs.Root>
 	</Dialog.Content>
 </Dialog.Root>

--- a/src/lib/components/kind-viewer/kind-viewer-actions/default/log-viewer.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/default/log-viewer.svelte
@@ -1,16 +1,16 @@
 <script lang="ts">
 	import { createClient, type Transport } from '@connectrpc/connect';
 	import ArrowDownIcon from '@lucide/svelte/icons/arrow-down';
-	import DownloadIcon from '@lucide/svelte/icons/download';
-	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
-	import PauseIcon from '@lucide/svelte/icons/pause';
-	import PlayIcon from '@lucide/svelte/icons/play';
+	import SearchIcon from '@lucide/svelte/icons/search';
 	import { RuntimeService } from '@otterscale/api/runtime/v1';
-	import { getContext, type Snippet, tick } from 'svelte';
+	import { getContext, onDestroy, type Snippet, tick } from 'svelte';
 
-	import Button from '$lib/components/ui/button/button.svelte';
+	import { Badge } from '$lib/components/ui/badge';
+	import { Button } from '$lib/components/ui/button';
+	import * as Empty from '$lib/components/ui/empty';
 	import { Select, SelectContent, SelectItem, SelectTrigger } from '$lib/components/ui/select';
-	import { Toggle } from '$lib/components/ui/toggle';
+	import { Spinner } from '$lib/components/ui/spinner';
+	import { cn } from '$lib/utils';
 
 	const MAX_LINES = 1000;
 
@@ -20,14 +20,14 @@
 		podName,
 		containers,
 		active = false,
-		extraControls
+		sourceControls
 	}: {
 		cluster: string;
 		namespace: string;
 		podName: string;
 		containers: string[];
 		active: boolean;
-		extraControls?: Snippet<[{ restart: () => void }]>;
+		sourceControls?: Snippet;
 	} = $props();
 
 	const transport: Transport = getContext('transport');
@@ -38,18 +38,61 @@
 
 	let follow = $state(true);
 	let previous = $state(false);
-	let logLines = $state<string[]>([]);
+	// Reassigned wholesale on every chunk — $state.raw skips deep-proxying 1000 lines.
+	let logLines = $state.raw<string[]>([]);
+	let droppedLines = $state(0);
 	let abortController: AbortController | null = null;
 	let logContainer = $state<HTMLElement | undefined>(undefined);
 	let showScrollButton = $state(false);
-	let showAllData = $state(false);
 	let downloading = $state(false);
+	let wrap = $state(false);
+	let filter = $state('');
+	let debouncedFilter = $state('');
+	let filterTimer: ReturnType<typeof setTimeout> | undefined;
+	let copied = $state(false);
 
-	$effect(() => {
-		if (active) {
-			startStreaming();
+	onDestroy(() => clearTimeout(filterTimer));
+
+	const entries = $derived(logLines.map((text, i) => ({ text, no: droppedLines + i + 1 })));
+
+	const filteredLines = $derived.by(() => {
+		const query = debouncedFilter.trim().toLowerCase();
+		if (!query) return entries;
+		return entries.filter((entry) => entry.text.toLowerCase().includes(query));
+	});
+
+	function highlightSegments(text: string, query: string): { text: string; hit: boolean }[] {
+		const trimmed = query.trim();
+		if (!trimmed) return [{ text, hit: false }];
+		const lower = text.toLowerCase();
+		const lowerQuery = trimmed.toLowerCase();
+		const parts: { text: string; hit: boolean }[] = [];
+		let index = 0;
+		while (index < text.length) {
+			const hitIndex = lower.indexOf(lowerQuery, index);
+			if (hitIndex === -1) {
+				parts.push({ text: text.slice(index), hit: false });
+				break;
+			}
+			if (hitIndex > index) parts.push({ text: text.slice(index, hitIndex), hit: false });
+			parts.push({ text: text.slice(hitIndex, hitIndex + trimmed.length), hit: true });
+			index = hitIndex + trimmed.length;
 		}
+		return parts;
+	}
 
+	const streamParams = $derived({
+		name: podName,
+		container: effectiveContainer,
+		follow,
+		previous
+	});
+
+	// Single restart source: reading streamParams registers every stream input as a
+	// dependency, so changing pod, container, follow or previous restarts exactly once.
+	$effect(() => {
+		if (!active) return;
+		startStreaming(streamParams);
 		return () => stopStreaming();
 	});
 
@@ -85,11 +128,12 @@
 		return new Promise((resolve) => setTimeout(resolve, ms));
 	}
 
-	async function startStreaming() {
+	async function startStreaming(params: typeof streamParams) {
 		stopStreaming();
 		logLines = [];
+		droppedLines = 0;
 
-		if (!podName) {
+		if (!params.name) {
 			logLines = ['[Error] No pod name available.'];
 			return;
 		}
@@ -101,11 +145,11 @@
 				{
 					cluster,
 					namespace,
-					name: podName,
-					container: effectiveContainer,
-					follow,
-					previous,
-					...(showAllData ? {} : { tailLines: BigInt(MAX_LINES) })
+					name: params.name,
+					container: params.container,
+					follow: params.follow,
+					previous: params.previous,
+					tailLines: BigInt(MAX_LINES)
 				},
 				{ signal: abortController.signal }
 			);
@@ -116,7 +160,10 @@
 					const lines = text.split('\n').filter((l) => l.length > 0);
 
 					const newLogLines = [...logLines, ...lines];
-					logLines = showAllData ? newLogLines : newLogLines.slice(-MAX_LINES);
+					if (newLogLines.length > MAX_LINES) {
+						droppedLines += newLogLines.length - MAX_LINES;
+					}
+					logLines = newLogLines.slice(-MAX_LINES);
 
 					autoScrollToBottom();
 					await delay(10);
@@ -135,7 +182,73 @@
 		}
 	}
 
-	async function downloadLogs() {
+	export function restart() {
+		if (active) startStreaming(streamParams);
+	}
+
+	export function isEmpty() {
+		return logLines.length === 0;
+	}
+
+	export function isCopied() {
+		return copied;
+	}
+
+	export function isDownloading() {
+		return downloading;
+	}
+
+	export function canDownload() {
+		return !!podName && !downloading;
+	}
+
+	export function getFilter() {
+		return filter;
+	}
+
+	export function setFilter(value: string) {
+		filter = value;
+		clearTimeout(filterTimer);
+		// Clearing should feel instant; only debounce while narrowing.
+		if (!value.trim()) {
+			debouncedFilter = value;
+			return;
+		}
+		filterTimer = setTimeout(() => (debouncedFilter = value), 150);
+	}
+
+	export function isFollowing() {
+		return follow;
+	}
+
+	export function setFollowing(value: boolean) {
+		follow = value;
+	}
+
+	export function isPrevious() {
+		return previous;
+	}
+
+	export function setPrevious(value: boolean) {
+		previous = value;
+	}
+
+	export function isWrapped() {
+		return wrap;
+	}
+
+	export function setWrap(value: boolean) {
+		wrap = value;
+	}
+
+	export async function copyLogs() {
+		if (logLines.length === 0) return;
+		await navigator.clipboard.writeText(logLines.join('\n'));
+		copied = true;
+		setTimeout(() => (copied = false), 1500);
+	}
+
+	export async function downloadLogs() {
 		if (!podName || downloading) return;
 		downloading = true;
 
@@ -175,102 +288,80 @@
 	}
 </script>
 
-<!-- Controls -->
-<div class="flex flex-wrap items-center gap-2">
-	{#if extraControls}
-		{@render extraControls({ restart: startStreaming })}
-	{/if}
-	{#if containers.length > 1}
-		<Select
-			type="single"
-			value={effectiveContainer}
-			onValueChange={(value) => {
-				overriddenContainer = value;
-				if (active) startStreaming();
-			}}
-		>
-			<SelectTrigger class="w-48 max-w-64 min-w-0">
-				<span class="truncate">{effectiveContainer || 'Select container'}</span>
-			</SelectTrigger>
-			<SelectContent class="w-48 max-w-64">
-				{#each containers as c (c)}
-					<SelectItem value={c}>{c}</SelectItem>
-				{/each}
-			</SelectContent>
-		</Select>
-	{/if}
-	<Toggle
-		size="sm"
-		pressed={follow}
-		onPressedChange={(v) => {
-			follow = v;
-			if (active) startStreaming();
-		}}
-		aria-label="Toggle follow"
-	>
-		{#if follow}
-			<PauseIcon size={14} />
-		{:else}
-			<PlayIcon size={14} />
-		{/if}
-		<span class="text-xs">{follow ? 'Following' : 'Paused'}</span>
-	</Toggle>
-	<Toggle
-		size="sm"
-		pressed={previous}
-		onPressedChange={(v) => {
-			previous = v;
-			if (active) startStreaming();
-		}}
-		aria-label="Toggle previous container"
-	>
-		<span class="text-xs">Previous</span>
-	</Toggle>
-	<Toggle
-		size="sm"
-		pressed={showAllData}
-		onPressedChange={(v) => {
-			showAllData = v;
-			if (active) startStreaming();
-		}}
-		aria-label="Toggle all data"
-	>
-		<span class="text-xs">All</span>
-	</Toggle>
-	<div class="ml-auto flex items-center gap-2">
-		<Button size="sm" variant="outline" onclick={downloadLogs} disabled={downloading || !podName}>
-			{#if downloading}
-				<LoaderCircleIcon size={14} class="animate-spin" />
-			{:else}
-				<DownloadIcon size={14} />
-			{/if}
-			{downloading ? 'Downloading...' : 'Download'}
-		</Button>
-		<Button
-			size="sm"
-			variant="outline"
-			onclick={() => {
-				if (active) startStreaming();
-			}}
-		>
-			Refresh
-		</Button>
-	</div>
-</div>
-
 <!-- Log output -->
-<div class="relative">
+<div class="relative min-h-64 flex-1">
 	<div
 		bind:this={logContainer}
 		onscroll={handleScroll}
-		class="h-[55vh] overflow-auto rounded-md border bg-muted p-3 font-mono text-xs leading-relaxed"
+		class="absolute inset-0 overflow-auto rounded-md border bg-muted py-2 font-mono text-xs leading-relaxed"
 	>
 		{#if logLines.length === 0}
-			<span class="text-muted-foreground">Waiting for log data...</span>
+			<Empty.Root class="h-full">
+				<Empty.Header>
+					<Empty.Media variant="icon">
+						<Spinner />
+					</Empty.Media>
+					<Empty.Title>Waiting for logs</Empty.Title>
+					<Empty.Description>
+						Log data will appear here as soon as the container produces output.
+					</Empty.Description>
+				</Empty.Header>
+			</Empty.Root>
+		{:else if filteredLines.length === 0}
+			<Empty.Root class="h-full">
+				<Empty.Header>
+					<Empty.Media variant="icon">
+						<SearchIcon />
+					</Empty.Media>
+					<Empty.Title>No matching lines</Empty.Title>
+					<Empty.Description>No log lines match "{debouncedFilter}".</Empty.Description>
+				</Empty.Header>
+			</Empty.Root>
 		{:else}
-			{#each logLines as line, i (i)}
-				<div class="hover:bg-muted-foreground/10">{line}</div>
+			{#each filteredLines as entry (entry.no)}
+				<div
+					class={cn(
+						'px-3 hover:bg-muted-foreground/10',
+						wrap ? 'break-all whitespace-pre-wrap' : 'w-fit min-w-full whitespace-pre',
+						entry.text.startsWith('[Error]') && 'text-destructive'
+					)}
+				>
+					{#if debouncedFilter.trim()}
+						{#each highlightSegments(entry.text, debouncedFilter) as segment, i (i)}
+							{#if segment.hit}<mark class="rounded-sm bg-primary/25 text-inherit"
+									>{segment.text}</mark
+								>{:else}{segment.text}{/if}
+						{/each}
+					{:else}
+						{entry.text}
+					{/if}
+				</div>
 			{/each}
+		{/if}
+	</div>
+
+	<!-- Source pickers float over the log's top-right corner; clear of the scrollbar. -->
+	<div class="absolute top-2 right-5 flex flex-wrap items-center justify-end gap-2">
+		{#if sourceControls}
+			{@render sourceControls()}
+		{/if}
+		{#if containers.length > 1}
+			<Select
+				type="single"
+				value={effectiveContainer}
+				onValueChange={(value) => (overriddenContainer = value)}
+			>
+				<SelectTrigger class="h-8 w-44 bg-background/90 shadow-sm backdrop-blur-sm">
+					<span class="truncate">{effectiveContainer || 'Select container'}</span>
+				</SelectTrigger>
+				<SelectContent class="w-(--bits-select-anchor-width) min-w-0">
+					{#each containers as c (c)}
+						<SelectItem value={c}>
+							<span class="block truncate">{c}</span>
+						</SelectItem>
+					{/each}
+				</SelectContent>
+			</Select>
 		{/if}
 	</div>
 
@@ -281,9 +372,36 @@
 			}}
 			variant="outline"
 			size="icon-sm"
-			class="absolute bottom-2 left-1/2 inline-flex -translate-x-1/2 transform rounded-full shadow-md"
+			class="absolute bottom-2 left-1/2 -translate-x-1/2 rounded-full shadow-md"
+			aria-label="Scroll to bottom"
 		>
-			<ArrowDownIcon size={14} />
+			<ArrowDownIcon />
 		</Button>
 	{/if}
+</div>
+
+<!-- Status bar -->
+<div class="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+	<Badge variant="outline" class="gap-1.5 font-normal">
+		<span
+			class={cn(
+				'size-1.5 rounded-full',
+				follow && active ? 'animate-pulse bg-primary' : 'bg-muted-foreground'
+			)}
+		></span>
+		{follow ? 'Streaming' : 'Paused'}
+	</Badge>
+	{#if previous}
+		<Badge variant="secondary" class="font-normal">Previous container</Badge>
+	{/if}
+	<span class="ml-auto">
+		{#if debouncedFilter.trim()}
+			{filteredLines.length} of {logLines.length} lines
+		{:else}
+			{logLines.length} lines
+		{/if}
+		{#if droppedLines > 0}
+			· showing last {MAX_LINES}
+		{/if}
+	</span>
 </div>

--- a/src/lib/components/kind-viewer/kind-viewer-actions/default/log.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/default/log.svelte
@@ -1,12 +1,28 @@
 <script lang="ts">
 	import { type Transport } from '@connectrpc/connect';
+	import CheckIcon from '@lucide/svelte/icons/check';
+	import CopyIcon from '@lucide/svelte/icons/copy';
+	import DownloadIcon from '@lucide/svelte/icons/download';
+	import HistoryIcon from '@lucide/svelte/icons/history';
+	import PauseIcon from '@lucide/svelte/icons/pause';
+	import PlayIcon from '@lucide/svelte/icons/play';
+	import RotateCwIcon from '@lucide/svelte/icons/rotate-cw';
 	import ScrollTextIcon from '@lucide/svelte/icons/scroll-text';
+	import SearchIcon from '@lucide/svelte/icons/search';
+	import WrapTextIcon from '@lucide/svelte/icons/wrap-text';
+	import XIcon from '@lucide/svelte/icons/x';
 	import { getContext, type Snippet } from 'svelte';
 
+	import { Button } from '$lib/components/ui/button';
 	import * as Dialog from '$lib/components/ui/dialog';
+	import * as InputGroup from '$lib/components/ui/input-group';
 	import * as Item from '$lib/components/ui/item';
 	import { Select, SelectContent, SelectItem, SelectTrigger } from '$lib/components/ui/select';
+	import { Spinner } from '$lib/components/ui/spinner';
+	import { Toggle } from '$lib/components/ui/toggle';
+	import * as Tooltip from '$lib/components/ui/tooltip';
 
+	import { ACTION_DIALOG_CONTENT_CLASS } from './constants';
 	import LogViewer from './log-viewer.svelte';
 	import { createPodResolver } from './pod-resolver.svelte';
 
@@ -29,6 +45,7 @@
 	const resolver = createPodResolver(() => ({ transport, cluster, object, kind }));
 
 	let open = $state(false);
+	let viewer = $state<ReturnType<typeof LogViewer>>();
 
 	async function handleOpenChange(isOpen: boolean) {
 		if (!isOpen || kind === 'Pod') return;
@@ -51,36 +68,183 @@
 			</Item.Root>
 		</Dialog.Trigger>
 	{/if}
-	<Dialog.Content class="flex h-fit max-h-[80vh] max-w-[70vw] min-w-[55vw] flex-col gap-3">
+	<Dialog.Content class={ACTION_DIALOG_CONTENT_CLASS}>
 		<Dialog.Header>
-			<Dialog.Title>Pod Logs — {resolver.effectivePodName || resolver.name}</Dialog.Title>
-			<Dialog.Description
-				>Streaming logs from namespace <strong>{resolver.namespace}</strong></Dialog.Description
-			>
+			<div class="flex items-end justify-between gap-4">
+				<div class="flex flex-col gap-1.5 text-left">
+					<Dialog.Title class="text-lg font-bold">
+						Pod Logs — {resolver.effectivePodName || resolver.name}
+					</Dialog.Title>
+					<Dialog.Description>
+						Streaming logs from namespace <strong>{resolver.namespace}</strong>
+					</Dialog.Description>
+				</div>
+				<!-- -mr-2 lines the icon column up with the dialog's close button (right-4 vs p-6). -->
+				<div class="-mr-2 flex shrink-0 items-center gap-1">
+					<InputGroup.Root class="h-8 w-48">
+						<InputGroup.Addon>
+							<SearchIcon />
+						</InputGroup.Addon>
+						<InputGroup.Input
+							placeholder="Filter lines..."
+							bind:value={() => viewer?.getFilter() ?? '', (v) => viewer?.setFilter(v ?? '')}
+						/>
+						{#if viewer?.getFilter()}
+							<InputGroup.Addon align="inline-end">
+								<InputGroup.Button
+									size="icon-xs"
+									aria-label="Clear filter"
+									onclick={() => viewer?.setFilter('')}
+								>
+									<XIcon />
+								</InputGroup.Button>
+							</InputGroup.Addon>
+						{/if}
+					</InputGroup.Root>
+					<Tooltip.Root ignoreNonKeyboardFocus>
+						<Tooltip.Trigger>
+							{#snippet child({ props })}
+								<Toggle
+									{...props}
+									size="sm"
+									class="size-8 p-0"
+									pressed={viewer?.isFollowing() ?? true}
+									onPressedChange={(v) => viewer?.setFollowing(v)}
+									aria-label="Toggle follow"
+								>
+									{#if viewer?.isFollowing() ?? true}
+										<PauseIcon />
+									{:else}
+										<PlayIcon />
+									{/if}
+								</Toggle>
+							{/snippet}
+						</Tooltip.Trigger>
+						<Tooltip.Content>
+							{(viewer?.isFollowing() ?? true) ? 'Pause streaming' : 'Resume streaming'}
+						</Tooltip.Content>
+					</Tooltip.Root>
+					<Tooltip.Root ignoreNonKeyboardFocus>
+						<Tooltip.Trigger>
+							{#snippet child({ props })}
+								<Toggle
+									{...props}
+									size="sm"
+									class="size-8 p-0"
+									pressed={viewer?.isPrevious() ?? false}
+									onPressedChange={(v) => viewer?.setPrevious(v)}
+									aria-label="Toggle previous container"
+								>
+									<HistoryIcon />
+								</Toggle>
+							{/snippet}
+						</Tooltip.Trigger>
+						<Tooltip.Content>Show logs from the previous container instance</Tooltip.Content>
+					</Tooltip.Root>
+					<Tooltip.Root ignoreNonKeyboardFocus>
+						<Tooltip.Trigger>
+							{#snippet child({ props })}
+								<Toggle
+									{...props}
+									size="sm"
+									class="size-8 p-0"
+									pressed={viewer?.isWrapped() ?? false}
+									onPressedChange={(v) => viewer?.setWrap(v)}
+									aria-label="Toggle line wrap"
+								>
+									<WrapTextIcon />
+								</Toggle>
+							{/snippet}
+						</Tooltip.Trigger>
+						<Tooltip.Content>Wrap long lines</Tooltip.Content>
+					</Tooltip.Root>
+					<Tooltip.Root ignoreNonKeyboardFocus>
+						<Tooltip.Trigger>
+							{#snippet child({ props })}
+								<Button
+									{...props}
+									size="icon-sm"
+									variant="ghost"
+									disabled={!viewer || viewer.isEmpty()}
+									onclick={() => viewer?.copyLogs()}
+									aria-label="Copy logs"
+								>
+									{#if viewer?.isCopied()}
+										<CheckIcon />
+									{:else}
+										<CopyIcon />
+									{/if}
+								</Button>
+							{/snippet}
+						</Tooltip.Trigger>
+						<Tooltip.Content>
+							{viewer?.isCopied() ? 'Copied!' : 'Copy logs to clipboard'}
+						</Tooltip.Content>
+					</Tooltip.Root>
+					<Tooltip.Root ignoreNonKeyboardFocus>
+						<Tooltip.Trigger>
+							{#snippet child({ props })}
+								<Button
+									{...props}
+									size="icon-sm"
+									variant="ghost"
+									disabled={!viewer || !viewer.canDownload()}
+									onclick={() => viewer?.downloadLogs()}
+									aria-label="Download logs"
+								>
+									{#if viewer?.isDownloading()}
+										<Spinner />
+									{:else}
+										<DownloadIcon />
+									{/if}
+								</Button>
+							{/snippet}
+						</Tooltip.Trigger>
+						<Tooltip.Content>Download full log file</Tooltip.Content>
+					</Tooltip.Root>
+					<Tooltip.Root ignoreNonKeyboardFocus>
+						<Tooltip.Trigger>
+							{#snippet child({ props })}
+								<Button
+									{...props}
+									size="icon-sm"
+									variant="ghost"
+									disabled={!viewer}
+									onclick={() => viewer?.restart()}
+									aria-label="Refresh logs"
+								>
+									<RotateCwIcon />
+								</Button>
+							{/snippet}
+						</Tooltip.Trigger>
+						<Tooltip.Content>Restart the log stream</Tooltip.Content>
+					</Tooltip.Root>
+				</div>
+			</div>
 		</Dialog.Header>
 		<LogViewer
+			bind:this={viewer}
 			{cluster}
 			namespace={resolver.namespace}
 			podName={resolver.effectivePodName}
 			containers={resolver.containers}
 			active={open}
 		>
-			{#snippet extraControls({ restart })}
+			{#snippet sourceControls()}
 				{#if kind === 'CronJob' && resolver.associatedJobs.length > 0}
 					<Select
 						type="single"
 						value={resolver.selectedJob}
-						onValueChange={async (value) => {
-							await resolver.handleJobChange(value);
-							if (open) restart();
-						}}
+						onValueChange={(value) => resolver.handleJobChange(value)}
 					>
-						<SelectTrigger class="w-56 max-w-64 min-w-0">
+						<SelectTrigger class="h-8 w-56 bg-background/90 shadow-sm backdrop-blur-sm">
 							<span class="truncate">{resolver.selectedJob || 'Select job'}</span>
 						</SelectTrigger>
-						<SelectContent class="w-56 max-w-64">
+						<SelectContent class="w-(--bits-select-anchor-width) min-w-0">
 							{#each resolver.associatedJobs as j (j)}
-								<SelectItem value={j}>{j}</SelectItem>
+								<SelectItem value={j}>
+									<span class="block truncate">{j}</span>
+								</SelectItem>
 							{/each}
 						</SelectContent>
 					</Select>
@@ -89,17 +253,16 @@
 					<Select
 						type="single"
 						value={resolver.selectedPod}
-						onValueChange={(value) => {
-							resolver.selectedPod = value;
-							if (open) restart();
-						}}
+						onValueChange={(value) => (resolver.selectedPod = value)}
 					>
-						<SelectTrigger class="w-64 max-w-64 min-w-0">
+						<SelectTrigger class="h-8 w-56 bg-background/90 shadow-sm backdrop-blur-sm">
 							<span class="truncate">{resolver.selectedPod || 'Select pod'}</span>
 						</SelectTrigger>
-						<SelectContent class="w-64 max-w-64">
+						<SelectContent class="w-(--bits-select-anchor-width) min-w-0">
 							{#each resolver.associatedPods as p (p)}
-								<SelectItem value={p}>{p}</SelectItem>
+								<SelectItem value={p}>
+									<span class="block truncate">{p}</span>
+								</SelectItem>
 							{/each}
 						</SelectContent>
 					</Select>

--- a/src/lib/components/kind-viewer/kind-viewer-actions/default/terminal.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/default/terminal.svelte
@@ -8,6 +8,7 @@
 	import * as Item from '$lib/components/ui/item';
 	import { Select, SelectContent, SelectItem, SelectTrigger } from '$lib/components/ui/select';
 
+	import { ACTION_DIALOG_CONTENT_FIT_CLASS } from './constants';
 	import { createPodResolver } from './pod-resolver.svelte';
 
 	let {
@@ -56,72 +57,19 @@
 			</Item.Root>
 		</Dialog.Trigger>
 	{/if}
-	<Dialog.Content class="flex h-fit max-h-[80vh] max-w-[70vw] min-w-[55vw] flex-col gap-3">
+	<Dialog.Content class={ACTION_DIALOG_CONTENT_FIT_CLASS}>
 		<Dialog.Header>
-			<Dialog.Title>Terminal — {resolver.effectivePodName || resolver.name}</Dialog.Title>
-			<Dialog.Description>
-				Interactive shell in namespace <strong>{resolver.namespace}</strong>
-			</Dialog.Description>
+			<div class="flex flex-col gap-1.5 text-left">
+				<Dialog.Title class="text-lg font-bold">
+					Terminal — {resolver.effectivePodName || resolver.name}
+				</Dialog.Title>
+				<Dialog.Description>
+					Interactive shell in namespace <strong>{resolver.namespace}</strong>
+				</Dialog.Description>
+			</div>
 		</Dialog.Header>
 
-		<div class="flex flex-wrap items-center gap-2">
-			{#if kind === 'CronJob' && resolver.associatedJobs.length > 0}
-				<Select
-					type="single"
-					value={resolver.selectedJob}
-					onValueChange={async (value) => {
-						await resolver.handleJobChange(value);
-					}}
-				>
-					<SelectTrigger class="w-56 max-w-64 min-w-0">
-						<span class="truncate">{resolver.selectedJob || 'Select job'}</span>
-					</SelectTrigger>
-					<SelectContent class="w-56 max-w-64">
-						{#each resolver.associatedJobs as j (j)}
-							<SelectItem value={j}>{j}</SelectItem>
-						{/each}
-					</SelectContent>
-				</Select>
-			{/if}
-			{#if kind !== 'Pod' && resolver.associatedPods.length > 1}
-				<Select
-					type="single"
-					value={resolver.selectedPod}
-					onValueChange={(value) => {
-						resolver.selectedPod = value;
-					}}
-				>
-					<SelectTrigger class="w-64 max-w-64 min-w-0">
-						<span class="truncate">{resolver.selectedPod || 'Select pod'}</span>
-					</SelectTrigger>
-					<SelectContent class="w-64 max-w-64">
-						{#each resolver.associatedPods as p (p)}
-							<SelectItem value={p}>{p}</SelectItem>
-						{/each}
-					</SelectContent>
-				</Select>
-			{/if}
-			{#if resolver.containers.length > 1}
-				<Select
-					type="single"
-					value={resolver.selectedContainer}
-					onValueChange={(value) => {
-						if (value) resolver.selectedContainer = value;
-					}}
-				>
-					<SelectTrigger class="w-48">
-						{resolver.selectedContainer || 'Select container'}
-					</SelectTrigger>
-					<SelectContent>
-						{#each resolver.containers as c (c)}
-							<SelectItem value={c}>{c}</SelectItem>
-						{/each}
-					</SelectContent>
-				</Select>
-			{/if}
-		</div>
-
-		<div class="h-[55vh] overflow-hidden rounded-md border bg-[#1e1e1e] p-3">
+		<div class="relative h-[55vh] overflow-hidden rounded-md border bg-[#1e1e1e] p-3">
 			{#if showTerminal && resolver.selectedContainer && resolver.effectivePodName}
 				{#key `${resolver.effectivePodName}-${resolver.selectedContainer}`}
 					<Terminal
@@ -133,6 +81,70 @@
 					/>
 				{/key}
 			{/if}
+
+			<!-- Source pickers float over the terminal's top-right corner. -->
+			<div class="absolute top-2 right-5 flex flex-wrap items-center justify-end gap-2">
+				{#if kind === 'CronJob' && resolver.associatedJobs.length > 0}
+					<Select
+						type="single"
+						value={resolver.selectedJob}
+						onValueChange={async (value) => {
+							await resolver.handleJobChange(value);
+						}}
+					>
+						<SelectTrigger class="h-8 w-56 bg-background/90 shadow-sm backdrop-blur-sm">
+							<span class="truncate">{resolver.selectedJob || 'Select job'}</span>
+						</SelectTrigger>
+						<SelectContent class="w-(--bits-select-anchor-width) min-w-0">
+							{#each resolver.associatedJobs as j (j)}
+								<SelectItem value={j}>
+									<span class="block truncate">{j}</span>
+								</SelectItem>
+							{/each}
+						</SelectContent>
+					</Select>
+				{/if}
+				{#if kind !== 'Pod' && resolver.associatedPods.length > 1}
+					<Select
+						type="single"
+						value={resolver.selectedPod}
+						onValueChange={(value) => {
+							resolver.selectedPod = value;
+						}}
+					>
+						<SelectTrigger class="h-8 w-56 bg-background/90 shadow-sm backdrop-blur-sm">
+							<span class="truncate">{resolver.selectedPod || 'Select pod'}</span>
+						</SelectTrigger>
+						<SelectContent class="w-(--bits-select-anchor-width) min-w-0">
+							{#each resolver.associatedPods as p (p)}
+								<SelectItem value={p}>
+									<span class="block truncate">{p}</span>
+								</SelectItem>
+							{/each}
+						</SelectContent>
+					</Select>
+				{/if}
+				{#if resolver.containers.length > 1}
+					<Select
+						type="single"
+						value={resolver.selectedContainer}
+						onValueChange={(value) => {
+							if (value) resolver.selectedContainer = value;
+						}}
+					>
+						<SelectTrigger class="h-8 w-44 bg-background/90 shadow-sm backdrop-blur-sm">
+							<span class="truncate">{resolver.selectedContainer || 'Select container'}</span>
+						</SelectTrigger>
+						<SelectContent class="w-(--bits-select-anchor-width) min-w-0">
+							{#each resolver.containers as c (c)}
+								<SelectItem value={c}>
+									<span class="block truncate">{c}</span>
+								</SelectItem>
+							{/each}
+						</SelectContent>
+					</Select>
+				{/if}
+			</div>
 		</div>
 	</Dialog.Content>
 </Dialog.Root>

--- a/src/lib/components/kind-viewer/kind-viewer-actions/default/view.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/default/view.svelte
@@ -1,12 +1,21 @@
 <script lang="ts">
+	import CheckIcon from '@lucide/svelte/icons/check';
+	import CopyIcon from '@lucide/svelte/icons/copy';
+	import DownloadIcon from '@lucide/svelte/icons/download';
 	import EyeIcon from '@lucide/svelte/icons/eye';
+	import FileCodeIcon from '@lucide/svelte/icons/file-code';
+	import FileJsonIcon from '@lucide/svelte/icons/file-json';
 	import type { Schema } from '@sjsf/form';
 	import lodash from 'lodash';
 	import { stringify } from 'yaml';
 
 	import * as Code from '$lib/components/custom/code';
+	import { Button } from '$lib/components/ui/button';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import * as Item from '$lib/components/ui/item';
+	import * as Tooltip from '$lib/components/ui/tooltip';
+
+	import { ACTION_DIALOG_CONTENT_CLASS } from './constants';
 
 	let {
 		schema,
@@ -18,7 +27,37 @@
 		onOpenChangeComplete?: () => void;
 	} = $props();
 
+	const name: string = $derived(object?.metadata?.name ?? object?.kind ?? '');
+	const yaml: string = $derived(stringify(object));
+	const json: string = $derived(
+		JSON.stringify(
+			object,
+			(key, value) => (typeof value === 'bigint' ? value.toString() : value),
+			2
+		)
+	);
+
 	let open = $state(false);
+	let copied = $state(false);
+	let mode = $state<'yaml' | 'json'>('yaml');
+
+	const content = $derived(mode === 'yaml' ? yaml : json);
+
+	async function copyContent() {
+		await navigator.clipboard.writeText(content);
+		copied = true;
+		setTimeout(() => (copied = false), 1500);
+	}
+
+	function downloadContent() {
+		const blob = new Blob([content], { type: 'text/plain' });
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement('a');
+		a.href = url;
+		a.download = `${name}.${mode}`;
+		a.click();
+		URL.revokeObjectURL(url);
+	}
 </script>
 
 <Dialog.Root bind:open {onOpenChangeComplete}>
@@ -32,19 +71,92 @@
 			</Item.Content>
 		</Item.Root>
 	</Dialog.Trigger>
-	<Dialog.Content class="flex h-fit max-h-[95vh] min-w-[50vw] flex-col justify-between">
+	<Dialog.Content class={ACTION_DIALOG_CONTENT_CLASS}>
 		<Dialog.Header>
-			<Item.Root class="p-0">
-				<Item.Content class="text-left">
-					<Item.Title class="text-lg font-bold">
-						{object.kind}
-					</Item.Title>
-					<Item.Description>{lodash.get(schema, 'description')}</Item.Description>
-				</Item.Content>
-			</Item.Root>
+			<div class="flex items-end justify-between gap-4">
+				<div class="flex flex-col gap-1.5 text-left">
+					<Dialog.Title class="text-lg font-bold">View — {name}</Dialog.Title>
+					<Dialog.Description>
+						{lodash.get(schema, 'description') || `${object.kind} manifest`}
+					</Dialog.Description>
+				</div>
+				<!-- -mr-2 lines the icon column up with the dialog's close button (right-4 vs p-6). -->
+				<div class="-mr-2 flex shrink-0 items-center gap-1">
+					<Tooltip.Root ignoreNonKeyboardFocus>
+						<Tooltip.Trigger>
+							{#snippet child({ props })}
+								<Button
+									{...props}
+									size="icon-sm"
+									variant="ghost"
+									disabled={mode === 'yaml'}
+									onclick={() => (mode = 'yaml')}
+									aria-label="YAML view"
+								>
+									<FileCodeIcon />
+								</Button>
+							{/snippet}
+						</Tooltip.Trigger>
+						<Tooltip.Content>YAML view</Tooltip.Content>
+					</Tooltip.Root>
+					<Tooltip.Root ignoreNonKeyboardFocus>
+						<Tooltip.Trigger>
+							{#snippet child({ props })}
+								<Button
+									{...props}
+									size="icon-sm"
+									variant="ghost"
+									disabled={mode === 'json'}
+									onclick={() => (mode = 'json')}
+									aria-label="JSON view"
+								>
+									<FileJsonIcon />
+								</Button>
+							{/snippet}
+						</Tooltip.Trigger>
+						<Tooltip.Content>JSON view</Tooltip.Content>
+					</Tooltip.Root>
+					<Tooltip.Root ignoreNonKeyboardFocus>
+						<Tooltip.Trigger>
+							{#snippet child({ props })}
+								<Button
+									{...props}
+									size="icon-sm"
+									variant="ghost"
+									onclick={copyContent}
+									aria-label="Copy to clipboard"
+								>
+									{#if copied}
+										<CheckIcon />
+									{:else}
+										<CopyIcon />
+									{/if}
+								</Button>
+							{/snippet}
+						</Tooltip.Trigger>
+						<Tooltip.Content>{copied ? 'Copied!' : 'Copy to clipboard'}</Tooltip.Content>
+					</Tooltip.Root>
+					<Tooltip.Root ignoreNonKeyboardFocus>
+						<Tooltip.Trigger>
+							{#snippet child({ props })}
+								<Button
+									{...props}
+									size="icon-sm"
+									variant="ghost"
+									onclick={downloadContent}
+									aria-label="Download manifest"
+								>
+									<DownloadIcon />
+								</Button>
+							{/snippet}
+						</Tooltip.Trigger>
+						<Tooltip.Content>Download as {mode === 'yaml' ? 'YAML' : 'JSON'}</Tooltip.Content>
+					</Tooltip.Root>
+				</div>
+			</div>
 		</Dialog.Header>
-		<Code.Root variant="secondary" lang="yaml" code={stringify(object)} class="w-full border-none">
-			<Code.CopyButton />
-		</Code.Root>
+		<div class="min-h-0 flex-1 overflow-auto rounded-md">
+			<Code.Root variant="secondary" lang={mode} code={content} class="h-full w-full border-none" />
+		</div>
 	</Dialog.Content>
 </Dialog.Root>

--- a/src/lib/components/kind-viewer/kind-viewer-actions/default/vnc.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/default/vnc.svelte
@@ -1,12 +1,17 @@
 <script lang="ts">
+	import CableIcon from '@lucide/svelte/icons/cable';
 	import MaximizeIcon from '@lucide/svelte/icons/maximize';
 	import MinimizeIcon from '@lucide/svelte/icons/minimize';
 	import MonitorIcon from '@lucide/svelte/icons/monitor';
+	import UnplugIcon from '@lucide/svelte/icons/unplug';
 
 	import { VncViewer } from '$lib/components/applications/vnc';
-	import Button from '$lib/components/ui/button/button.svelte';
+	import { Button } from '$lib/components/ui/button';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import * as Item from '$lib/components/ui/item';
+	import * as Tooltip from '$lib/components/ui/tooltip';
+
+	import { ACTION_DIALOG_CONTENT_FIT_CLASS } from './constants';
 
 	let {
 		cluster,
@@ -25,6 +30,12 @@
 	let open = $state(false);
 	let showVnc = $state(false);
 	let fullscreen = $state(false);
+	let connected = $state(false);
+	let vncKey = $state(0);
+
+	function reconnect() {
+		vncKey += 1;
+	}
 
 	function handleOpenChange(isOpen: boolean) {
 		if (isOpen) {
@@ -32,6 +43,7 @@
 		} else {
 			showVnc = false;
 			fullscreen = false;
+			connected = false;
 		}
 	}
 </script>
@@ -48,37 +60,76 @@
 		</Item.Root>
 	</Dialog.Trigger>
 	<Dialog.Content
-		class="flex flex-col gap-3 {fullscreen
-			? 'h-screen max-h-screen w-screen max-w-none rounded-none p-4 ring-0 sm:max-w-none'
-			: 'h-fit max-h-[85vh] max-w-[80vw] min-w-[60vw] sm:max-w-[80vw]'}"
+		class={fullscreen
+			? 'flex h-screen max-h-screen w-screen max-w-none flex-col gap-3 rounded-none p-4 ring-0 sm:max-w-none'
+			: ACTION_DIALOG_CONTENT_FIT_CLASS}
 	>
-		<Dialog.Header class="flex flex-row items-center justify-between">
-			<div>
-				<Dialog.Title>VNC Console — {vmiName}</Dialog.Title>
-				<Dialog.Description>
-					VNC console for VirtualMachine in namespace <strong>{namespace}</strong>
-				</Dialog.Description>
+		<Dialog.Header>
+			<div class="flex items-end justify-between gap-4">
+				<div class="flex flex-col gap-1.5 text-left">
+					<Dialog.Title class="text-lg font-bold">VNC Console — {vmiName}</Dialog.Title>
+					<Dialog.Description>
+						VNC console for VirtualMachine in namespace <strong>{namespace}</strong>
+					</Dialog.Description>
+				</div>
+				<!-- -mr-2 lines the icon column up with the dialog's close button (right-4 vs p-6). -->
+				<div class="-mr-2 flex shrink-0 items-center gap-1">
+					<Tooltip.Root ignoreNonKeyboardFocus>
+						<Tooltip.Trigger>
+							{#snippet child({ props })}
+								<Button
+									{...props}
+									size="icon-sm"
+									variant="ghost"
+									onclick={reconnect}
+									aria-label={connected ? 'Connected' : 'Reconnect'}
+								>
+									{#if connected}
+										<CableIcon />
+									{:else}
+										<UnplugIcon class="text-destructive" />
+									{/if}
+								</Button>
+							{/snippet}
+						</Tooltip.Trigger>
+						<Tooltip.Content>{connected ? 'Connected' : 'Reconnect'}</Tooltip.Content>
+					</Tooltip.Root>
+					<Tooltip.Root ignoreNonKeyboardFocus>
+						<Tooltip.Trigger>
+							{#snippet child({ props })}
+								<Button
+									{...props}
+									size="icon-sm"
+									variant="ghost"
+									aria-label={fullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+									onclick={() => (fullscreen = !fullscreen)}
+								>
+									{#if fullscreen}
+										<MinimizeIcon />
+									{:else}
+										<MaximizeIcon />
+									{/if}
+								</Button>
+							{/snippet}
+						</Tooltip.Trigger>
+						<Tooltip.Content>{fullscreen ? 'Exit fullscreen' : 'Fullscreen'}</Tooltip.Content>
+					</Tooltip.Root>
+				</div>
 			</div>
-			<Button
-				size="icon"
-				variant="ghost"
-				class="shrink-0"
-				aria-label={fullscreen ? 'Exit fullscreen' : 'Fullscreen'}
-				onclick={() => (fullscreen = !fullscreen)}
-			>
-				{#if fullscreen}
-					<MinimizeIcon size={16} />
-				{:else}
-					<MaximizeIcon size={16} />
-				{/if}
-			</Button>
 		</Dialog.Header>
 
 		<div
 			class="overflow-hidden rounded-md border bg-[#282828] {fullscreen ? 'flex-1' : 'h-[65vh]'}"
 		>
 			{#if showVnc}
-				<VncViewer {cluster} {namespace} name={vmiName} />
+				{#key vncKey}
+					<VncViewer
+						{cluster}
+						{namespace}
+						name={vmiName}
+						onConnectionChange={(v) => (connected = v)}
+					/>
+				{/key}
 			{/if}
 		</div>
 	</Dialog.Content>


### PR DESCRIPTION
Extract a shared ActionDialogHeader component and common dialog sizing classes (ACTION_DIALOG_CONTENT_CLASS / _FIT_CLASS) so describe, log, terminal, view, and vnc dialogs share one header/layout pattern with consistent tooltip-icon action buttons.

- log-viewer: move source pickers to a floating overlay, add line filtering with match highlighting, line-wrap toggle, copy-to-clipboard, a streaming status bar, and switch logLines to $state.raw for performance; consolidate stream restarts behind a single derived streamParams effect
- log: move follow/previous/wrap/copy/download/refresh controls into the dialog header, driven via the LogViewer instance's exported API
- describe: add copy-to-clipboard and richer loading/error states (Empty, Alert, Spinner)
- view: add YAML/JSON toggle, copy, and download actions
- vnc: add a reconnect button with live connection status, wired through a new onConnectionChange callback on VncViewer
- terminal: move container/pod/job source pickers to a floating overlay over the terminal