### PR TITLE
refactor: unify clipboard copy hook and hide source pickers when unne…

### DIFF
--- a/src/lib/components/kind-viewer/kind-viewer-actions/default/describe.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/default/describe.svelte
@@ -16,6 +16,7 @@
 	import { Spinner } from '$lib/components/ui/spinner';
 	import * as Tabs from '$lib/components/ui/tabs/index.js';
 	import * as Tooltip from '$lib/components/ui/tooltip';
+	import { UseClipboard } from '$lib/hooks/use-clipboard.svelte';
 
 	import { ACTION_DIALOG_CONTENT_CLASS } from './constants';
 	import { formatDescribe } from './describe-formatter';
@@ -88,14 +89,12 @@
 		}
 	}
 
-	let copied = $state(false);
+	const clipboard = new UseClipboard({ delay: 1000 });
 
 	async function copyContent() {
 		const text = mode === 'json' ? jsonText : describeText;
 		if (!text) return;
-		await navigator.clipboard.writeText(text);
-		copied = true;
-		setTimeout(() => (copied = false), 1500);
+		await clipboard.copy(text);
 	}
 
 	function handleOpenChange(isOpen: boolean) {
@@ -180,7 +179,7 @@
 									onclick={copyContent}
 									aria-label="Copy to clipboard"
 								>
-									{#if copied}
+									{#if clipboard.copied}
 										<CheckIcon />
 									{:else}
 										<CopyIcon />
@@ -188,7 +187,7 @@
 								</Button>
 							{/snippet}
 						</Tooltip.Trigger>
-						<Tooltip.Content>{copied ? 'Copied!' : 'Copy to clipboard'}</Tooltip.Content>
+						<Tooltip.Content>{clipboard.copied ? 'Copied!' : 'Copy to clipboard'}</Tooltip.Content>
 					</Tooltip.Root>
 				</div>
 			</div>

--- a/src/lib/components/kind-viewer/kind-viewer-actions/default/log-viewer.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/default/log-viewer.svelte
@@ -8,8 +8,8 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import { Button } from '$lib/components/ui/button';
 	import * as Empty from '$lib/components/ui/empty';
-	import { Select, SelectContent, SelectItem, SelectTrigger } from '$lib/components/ui/select';
 	import { Spinner } from '$lib/components/ui/spinner';
+	import { UseClipboard } from '$lib/hooks/use-clipboard.svelte';
 	import { cn } from '$lib/utils';
 
 	const MAX_LINES = 1000;
@@ -18,23 +18,20 @@
 		cluster,
 		namespace,
 		podName,
-		containers,
+		container,
 		active = false,
 		sourceControls
 	}: {
 		cluster: string;
 		namespace: string;
 		podName: string;
-		containers: string[];
+		container: string;
 		active: boolean;
 		sourceControls?: Snippet;
 	} = $props();
 
 	const transport: Transport = getContext('transport');
 	const client = createClient(RuntimeService, transport);
-
-	let overriddenContainer = $state<string | null>(null);
-	const effectiveContainer = $derived(overriddenContainer ?? containers[0] ?? '');
 
 	let follow = $state(true);
 	let previous = $state(false);
@@ -49,7 +46,8 @@
 	let filter = $state('');
 	let debouncedFilter = $state('');
 	let filterTimer: ReturnType<typeof setTimeout> | undefined;
-	let copied = $state(false);
+
+	const clipboard = new UseClipboard({ delay: 1000 });
 
 	onDestroy(() => clearTimeout(filterTimer));
 
@@ -83,7 +81,7 @@
 
 	const streamParams = $derived({
 		name: podName,
-		container: effectiveContainer,
+		container,
 		follow,
 		previous
 	});
@@ -191,7 +189,7 @@
 	}
 
 	export function isCopied() {
-		return copied;
+		return clipboard.copied;
 	}
 
 	export function isDownloading() {
@@ -243,9 +241,7 @@
 
 	export async function copyLogs() {
 		if (logLines.length === 0) return;
-		await navigator.clipboard.writeText(logLines.join('\n'));
-		copied = true;
-		setTimeout(() => (copied = false), 1500);
+		await clipboard.copy(logLines.join('\n'));
 	}
 
 	export async function downloadLogs() {
@@ -260,7 +256,7 @@
 					cluster,
 					namespace,
 					name: podName,
-					container: effectiveContainer,
+					container,
 					follow: false,
 					previous
 				},
@@ -277,7 +273,7 @@
 			const url = URL.createObjectURL(blob);
 			const a = document.createElement('a');
 			a.href = url;
-			a.download = `${podName}_${effectiveContainer}_${new Date().toISOString().replace(/[:.]/g, '-')}.log`;
+			a.download = `${podName}_${container}_${new Date().toISOString().replace(/[:.]/g, '-')}.log`;
 			a.click();
 			URL.revokeObjectURL(url);
 		} catch (error) {
@@ -293,7 +289,11 @@
 	<div
 		bind:this={logContainer}
 		onscroll={handleScroll}
-		class="absolute inset-0 overflow-auto rounded-md border bg-muted py-2 font-mono text-xs leading-relaxed"
+		class={cn(
+			'absolute inset-0 overflow-auto rounded-md border bg-muted pb-2 font-mono text-xs leading-relaxed',
+			// Floating pickers overlay the box's top-right; pad the content clear of them.
+			sourceControls ? 'pt-12' : 'pt-2'
+		)}
 	>
 		{#if logLines.length === 0}
 			<Empty.Root class="h-full">
@@ -340,30 +340,12 @@
 		{/if}
 	</div>
 
-	<!-- Source pickers float over the log's top-right corner; clear of the scrollbar. -->
-	<div class="absolute top-2 right-5 flex flex-wrap items-center justify-end gap-2">
-		{#if sourceControls}
+	{#if sourceControls}
+		<!-- Source pickers float over the log's top-right corner; clear of the scrollbar. -->
+		<div class="absolute top-2 right-5 flex flex-wrap items-center justify-end gap-2">
 			{@render sourceControls()}
-		{/if}
-		{#if containers.length > 1}
-			<Select
-				type="single"
-				value={effectiveContainer}
-				onValueChange={(value) => (overriddenContainer = value)}
-			>
-				<SelectTrigger class="h-8 w-44 bg-background/90 shadow-sm backdrop-blur-sm">
-					<span class="truncate">{effectiveContainer || 'Select container'}</span>
-				</SelectTrigger>
-				<SelectContent class="w-(--bits-select-anchor-width) min-w-0">
-					{#each containers as c (c)}
-						<SelectItem value={c}>
-							<span class="block truncate">{c}</span>
-						</SelectItem>
-					{/each}
-				</SelectContent>
-			</Select>
-		{/if}
-	</div>
+		</div>
+	{/if}
 
 	{#if showScrollButton}
 		<Button

--- a/src/lib/components/kind-viewer/kind-viewer-actions/default/log.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/default/log.svelte
@@ -47,11 +47,77 @@
 	let open = $state(false);
 	let viewer = $state<ReturnType<typeof LogViewer>>();
 
+	const showsPodPicker = $derived(kind !== 'Pod' && resolver.associatedPods.length > 1);
+	const hasPickers = $derived(
+		(kind === 'CronJob' && resolver.associatedJobs.length > 0) ||
+			showsPodPicker ||
+			resolver.containers.length > 1
+	);
+
 	async function handleOpenChange(isOpen: boolean) {
 		if (!isOpen || kind === 'Pod') return;
 		await resolver.resolve();
 	}
 </script>
+
+{#snippet sourcePickers()}
+	{#if kind === 'CronJob' && resolver.associatedJobs.length > 0}
+		<Select
+			type="single"
+			value={resolver.selectedJob}
+			onValueChange={(value) => resolver.handleJobChange(value)}
+		>
+			<SelectTrigger class="h-8 w-56 bg-background/90 shadow-sm backdrop-blur-sm">
+				<span class="truncate">{resolver.selectedJob || 'Select job'}</span>
+			</SelectTrigger>
+			<SelectContent class="w-(--bits-select-anchor-width) min-w-0">
+				{#each resolver.associatedJobs as j (j)}
+					<SelectItem value={j}>
+						<span class="block truncate">{j}</span>
+					</SelectItem>
+				{/each}
+			</SelectContent>
+		</Select>
+	{/if}
+	{#if showsPodPicker}
+		<Select
+			type="single"
+			value={resolver.selectedPod}
+			onValueChange={(value) => (resolver.selectedPod = value)}
+		>
+			<SelectTrigger class="h-8 w-56 bg-background/90 shadow-sm backdrop-blur-sm">
+				<span class="truncate">{resolver.selectedPod || 'Select pod'}</span>
+			</SelectTrigger>
+			<SelectContent class="w-(--bits-select-anchor-width) min-w-0">
+				{#each resolver.associatedPods as p (p)}
+					<SelectItem value={p}>
+						<span class="block truncate">{p}</span>
+					</SelectItem>
+				{/each}
+			</SelectContent>
+		</Select>
+	{/if}
+	{#if resolver.containers.length > 1}
+		<Select
+			type="single"
+			value={resolver.selectedContainer}
+			onValueChange={(value) => {
+				if (value) resolver.selectedContainer = value;
+			}}
+		>
+			<SelectTrigger class="h-8 w-44 bg-background/90 shadow-sm backdrop-blur-sm">
+				<span class="truncate">{resolver.selectedContainer || 'Select container'}</span>
+			</SelectTrigger>
+			<SelectContent class="w-(--bits-select-anchor-width) min-w-0">
+				{#each resolver.containers as c (c)}
+					<SelectItem value={c}>
+						<span class="block truncate">{c}</span>
+					</SelectItem>
+				{/each}
+			</SelectContent>
+		</Select>
+	{/if}
+{/snippet}
 
 <Dialog.Root bind:open {onOpenChangeComplete} onOpenChange={handleOpenChange}>
 	{#if trigger}
@@ -71,11 +137,11 @@
 	<Dialog.Content class={ACTION_DIALOG_CONTENT_CLASS}>
 		<Dialog.Header>
 			<div class="flex items-end justify-between gap-4">
-				<div class="flex flex-col gap-1.5 text-left">
-					<Dialog.Title class="text-lg font-bold">
+				<div class="flex min-w-0 flex-1 flex-col gap-1.5 text-left">
+					<Dialog.Title class="truncate text-lg font-bold">
 						Pod Logs — {resolver.effectivePodName || resolver.name}
 					</Dialog.Title>
-					<Dialog.Description>
+					<Dialog.Description class="truncate">
 						Streaming logs from namespace <strong>{resolver.namespace}</strong>
 					</Dialog.Description>
 				</div>
@@ -227,47 +293,9 @@
 			{cluster}
 			namespace={resolver.namespace}
 			podName={resolver.effectivePodName}
-			containers={resolver.containers}
+			container={resolver.selectedContainer}
 			active={open}
-		>
-			{#snippet sourceControls()}
-				{#if kind === 'CronJob' && resolver.associatedJobs.length > 0}
-					<Select
-						type="single"
-						value={resolver.selectedJob}
-						onValueChange={(value) => resolver.handleJobChange(value)}
-					>
-						<SelectTrigger class="h-8 w-56 bg-background/90 shadow-sm backdrop-blur-sm">
-							<span class="truncate">{resolver.selectedJob || 'Select job'}</span>
-						</SelectTrigger>
-						<SelectContent class="w-(--bits-select-anchor-width) min-w-0">
-							{#each resolver.associatedJobs as j (j)}
-								<SelectItem value={j}>
-									<span class="block truncate">{j}</span>
-								</SelectItem>
-							{/each}
-						</SelectContent>
-					</Select>
-				{/if}
-				{#if kind !== 'Pod' && resolver.associatedPods.length > 1}
-					<Select
-						type="single"
-						value={resolver.selectedPod}
-						onValueChange={(value) => (resolver.selectedPod = value)}
-					>
-						<SelectTrigger class="h-8 w-56 bg-background/90 shadow-sm backdrop-blur-sm">
-							<span class="truncate">{resolver.selectedPod || 'Select pod'}</span>
-						</SelectTrigger>
-						<SelectContent class="w-(--bits-select-anchor-width) min-w-0">
-							{#each resolver.associatedPods as p (p)}
-								<SelectItem value={p}>
-									<span class="block truncate">{p}</span>
-								</SelectItem>
-							{/each}
-						</SelectContent>
-					</Select>
-				{/if}
-			{/snippet}
-		</LogViewer>
+			sourceControls={hasPickers ? sourcePickers : undefined}
+		/>
 	</Dialog.Content>
 </Dialog.Root>

--- a/src/lib/components/kind-viewer/kind-viewer-actions/default/terminal.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/default/terminal.svelte
@@ -7,6 +7,7 @@
 	import * as Dialog from '$lib/components/ui/dialog';
 	import * as Item from '$lib/components/ui/item';
 	import { Select, SelectContent, SelectItem, SelectTrigger } from '$lib/components/ui/select';
+	import { cn } from '$lib/utils';
 
 	import { ACTION_DIALOG_CONTENT_FIT_CLASS } from './constants';
 	import { createPodResolver } from './pod-resolver.svelte';
@@ -31,6 +32,12 @@
 
 	let open = $state(false);
 	let showTerminal = $state(false);
+
+	const hasPickers = $derived(
+		(kind === 'CronJob' && resolver.associatedJobs.length > 0) ||
+			(kind !== 'Pod' && resolver.associatedPods.length > 1) ||
+			resolver.containers.length > 1
+	);
 
 	async function handleOpenChange(isOpen: boolean) {
 		if (isOpen) {
@@ -59,17 +66,23 @@
 	{/if}
 	<Dialog.Content class={ACTION_DIALOG_CONTENT_FIT_CLASS}>
 		<Dialog.Header>
-			<div class="flex flex-col gap-1.5 text-left">
-				<Dialog.Title class="text-lg font-bold">
+			<div class="flex min-w-0 flex-col gap-1.5 text-left">
+				<Dialog.Title class="truncate text-lg font-bold">
 					Terminal — {resolver.effectivePodName || resolver.name}
 				</Dialog.Title>
-				<Dialog.Description>
+				<Dialog.Description class="truncate">
 					Interactive shell in namespace <strong>{resolver.namespace}</strong>
 				</Dialog.Description>
 			</div>
 		</Dialog.Header>
 
-		<div class="relative h-[55vh] overflow-hidden rounded-md border bg-[#1e1e1e] p-3">
+		<div
+			class={cn(
+				'relative h-[55vh] overflow-hidden rounded-md border bg-[#1e1e1e] p-3',
+				// Floating pickers overlay the box's top-right; pad the shell clear of them.
+				hasPickers && 'pt-12'
+			)}
+		>
 			{#if showTerminal && resolver.selectedContainer && resolver.effectivePodName}
 				{#key `${resolver.effectivePodName}-${resolver.selectedContainer}`}
 					<Terminal
@@ -83,68 +96,70 @@
 			{/if}
 
 			<!-- Source pickers float over the terminal's top-right corner. -->
-			<div class="absolute top-2 right-5 flex flex-wrap items-center justify-end gap-2">
-				{#if kind === 'CronJob' && resolver.associatedJobs.length > 0}
-					<Select
-						type="single"
-						value={resolver.selectedJob}
-						onValueChange={async (value) => {
-							await resolver.handleJobChange(value);
-						}}
-					>
-						<SelectTrigger class="h-8 w-56 bg-background/90 shadow-sm backdrop-blur-sm">
-							<span class="truncate">{resolver.selectedJob || 'Select job'}</span>
-						</SelectTrigger>
-						<SelectContent class="w-(--bits-select-anchor-width) min-w-0">
-							{#each resolver.associatedJobs as j (j)}
-								<SelectItem value={j}>
-									<span class="block truncate">{j}</span>
-								</SelectItem>
-							{/each}
-						</SelectContent>
-					</Select>
-				{/if}
-				{#if kind !== 'Pod' && resolver.associatedPods.length > 1}
-					<Select
-						type="single"
-						value={resolver.selectedPod}
-						onValueChange={(value) => {
-							resolver.selectedPod = value;
-						}}
-					>
-						<SelectTrigger class="h-8 w-56 bg-background/90 shadow-sm backdrop-blur-sm">
-							<span class="truncate">{resolver.selectedPod || 'Select pod'}</span>
-						</SelectTrigger>
-						<SelectContent class="w-(--bits-select-anchor-width) min-w-0">
-							{#each resolver.associatedPods as p (p)}
-								<SelectItem value={p}>
-									<span class="block truncate">{p}</span>
-								</SelectItem>
-							{/each}
-						</SelectContent>
-					</Select>
-				{/if}
-				{#if resolver.containers.length > 1}
-					<Select
-						type="single"
-						value={resolver.selectedContainer}
-						onValueChange={(value) => {
-							if (value) resolver.selectedContainer = value;
-						}}
-					>
-						<SelectTrigger class="h-8 w-44 bg-background/90 shadow-sm backdrop-blur-sm">
-							<span class="truncate">{resolver.selectedContainer || 'Select container'}</span>
-						</SelectTrigger>
-						<SelectContent class="w-(--bits-select-anchor-width) min-w-0">
-							{#each resolver.containers as c (c)}
-								<SelectItem value={c}>
-									<span class="block truncate">{c}</span>
-								</SelectItem>
-							{/each}
-						</SelectContent>
-					</Select>
-				{/if}
-			</div>
+			{#if hasPickers}
+				<div class="absolute top-2 right-5 flex flex-wrap items-center justify-end gap-2">
+					{#if kind === 'CronJob' && resolver.associatedJobs.length > 0}
+						<Select
+							type="single"
+							value={resolver.selectedJob}
+							onValueChange={async (value) => {
+								await resolver.handleJobChange(value);
+							}}
+						>
+							<SelectTrigger class="h-8 w-56 bg-background/90 shadow-sm backdrop-blur-sm">
+								<span class="truncate">{resolver.selectedJob || 'Select job'}</span>
+							</SelectTrigger>
+							<SelectContent class="w-(--bits-select-anchor-width) min-w-0">
+								{#each resolver.associatedJobs as j (j)}
+									<SelectItem value={j}>
+										<span class="block truncate">{j}</span>
+									</SelectItem>
+								{/each}
+							</SelectContent>
+						</Select>
+					{/if}
+					{#if kind !== 'Pod' && resolver.associatedPods.length > 1}
+						<Select
+							type="single"
+							value={resolver.selectedPod}
+							onValueChange={(value) => {
+								resolver.selectedPod = value;
+							}}
+						>
+							<SelectTrigger class="h-8 w-56 bg-background/90 shadow-sm backdrop-blur-sm">
+								<span class="truncate">{resolver.selectedPod || 'Select pod'}</span>
+							</SelectTrigger>
+							<SelectContent class="w-(--bits-select-anchor-width) min-w-0">
+								{#each resolver.associatedPods as p (p)}
+									<SelectItem value={p}>
+										<span class="block truncate">{p}</span>
+									</SelectItem>
+								{/each}
+							</SelectContent>
+						</Select>
+					{/if}
+					{#if resolver.containers.length > 1}
+						<Select
+							type="single"
+							value={resolver.selectedContainer}
+							onValueChange={(value) => {
+								if (value) resolver.selectedContainer = value;
+							}}
+						>
+							<SelectTrigger class="h-8 w-44 bg-background/90 shadow-sm backdrop-blur-sm">
+								<span class="truncate">{resolver.selectedContainer || 'Select container'}</span>
+							</SelectTrigger>
+							<SelectContent class="w-(--bits-select-anchor-width) min-w-0">
+								{#each resolver.containers as c (c)}
+									<SelectItem value={c}>
+										<span class="block truncate">{c}</span>
+									</SelectItem>
+								{/each}
+							</SelectContent>
+						</Select>
+					{/if}
+				</div>
+			{/if}
 		</div>
 	</Dialog.Content>
 </Dialog.Root>

--- a/src/lib/components/kind-viewer/kind-viewer-actions/default/view.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/default/view.svelte
@@ -14,6 +14,7 @@
 	import * as Dialog from '$lib/components/ui/dialog';
 	import * as Item from '$lib/components/ui/item';
 	import * as Tooltip from '$lib/components/ui/tooltip';
+	import { UseClipboard } from '$lib/hooks/use-clipboard.svelte';
 
 	import { ACTION_DIALOG_CONTENT_CLASS } from './constants';
 
@@ -38,16 +39,11 @@
 	);
 
 	let open = $state(false);
-	let copied = $state(false);
 	let mode = $state<'yaml' | 'json'>('yaml');
 
 	const content = $derived(mode === 'yaml' ? yaml : json);
 
-	async function copyContent() {
-		await navigator.clipboard.writeText(content);
-		copied = true;
-		setTimeout(() => (copied = false), 1500);
-	}
+	const clipboard = new UseClipboard({ delay: 1000 });
 
 	function downloadContent() {
 		const blob = new Blob([content], { type: 'text/plain' });
@@ -123,10 +119,10 @@
 									{...props}
 									size="icon-sm"
 									variant="ghost"
-									onclick={copyContent}
+									onclick={() => clipboard.copy(content)}
 									aria-label="Copy to clipboard"
 								>
-									{#if copied}
+									{#if clipboard.copied}
 										<CheckIcon />
 									{:else}
 										<CopyIcon />
@@ -134,7 +130,7 @@
 								</Button>
 							{/snippet}
 						</Tooltip.Trigger>
-						<Tooltip.Content>{copied ? 'Copied!' : 'Copy to clipboard'}</Tooltip.Content>
+						<Tooltip.Content>{clipboard.copied ? 'Copied!' : 'Copy to clipboard'}</Tooltip.Content>
 					</Tooltip.Root>
 					<Tooltip.Root ignoreNonKeyboardFocus>
 						<Tooltip.Trigger>


### PR DESCRIPTION
…eded

Use the shared UseClipboard hook in describe/view/log-viewer instead of duplicating navigator.clipboard + timeout logic in each component. Log and terminal dialogs now only render pod/job/container pickers (and their padding) when there's more than one option to choose from, and container selection is lifted into log.svelte so log-viewer just renders the given container.