### PR TITLE
refactor: move log/terminal source pickers into an in-frame toolbar

### DIFF
--- a/src/lib/components/kind-viewer/kind-viewer-actions/default/log-viewer.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/default/log-viewer.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { createClient, type Transport } from '@connectrpc/connect';
 	import ArrowDownIcon from '@lucide/svelte/icons/arrow-down';
+	import ContainerIcon from '@lucide/svelte/icons/container';
 	import SearchIcon from '@lucide/svelte/icons/search';
 	import { RuntimeService } from '@otterscale/api/runtime/v1';
 	import { getContext, onDestroy, type Snippet, tick } from 'svelte';
@@ -20,6 +21,7 @@
 		podName,
 		container,
 		active = false,
+		containerControl,
 		sourceControls
 	}: {
 		cluster: string;
@@ -27,6 +29,7 @@
 		podName: string;
 		container: string;
 		active: boolean;
+		containerControl?: Snippet;
 		sourceControls?: Snippet;
 	} = $props();
 
@@ -286,66 +289,104 @@
 
 <!-- Log output -->
 <div class="relative min-h-64 flex-1">
-	<div
-		bind:this={logContainer}
-		onscroll={handleScroll}
-		class={cn(
-			'absolute inset-0 overflow-auto rounded-md border bg-muted pb-2 font-mono text-xs leading-relaxed',
-			// Floating pickers overlay the box's top-right; pad the content clear of them.
-			sourceControls ? 'pt-12' : 'pt-2'
-		)}
-	>
-		{#if logLines.length === 0}
-			<Empty.Root class="h-full">
-				<Empty.Header>
-					<Empty.Media variant="icon">
-						<Spinner />
-					</Empty.Media>
-					<Empty.Title>Waiting for logs</Empty.Title>
-					<Empty.Description>
-						Log data will appear here as soon as the container produces output.
-					</Empty.Description>
-				</Empty.Header>
-			</Empty.Root>
-		{:else if filteredLines.length === 0}
-			<Empty.Root class="h-full">
-				<Empty.Header>
-					<Empty.Media variant="icon">
-						<SearchIcon />
-					</Empty.Media>
-					<Empty.Title>No matching lines</Empty.Title>
-					<Empty.Description>No log lines match "{debouncedFilter}".</Empty.Description>
-				</Empty.Header>
-			</Empty.Root>
-		{:else}
-			{#each filteredLines as entry (entry.no)}
-				<div
-					class={cn(
-						'px-3 hover:bg-muted-foreground/10',
-						wrap ? 'break-all whitespace-pre-wrap' : 'w-fit min-w-full whitespace-pre',
-						entry.text.startsWith('[Error]') && 'text-destructive'
-					)}
-				>
+	<div class="absolute inset-0 flex flex-col overflow-hidden rounded-md border bg-muted">
+		<!-- In-frame toolbar: source info on the left, pickers on the right. The scroll
+		     area starts below it, so log lines never pass beneath the pickers. -->
+		<!-- Fixed h-10 keeps the toolbar the same height with or without pickers. -->
+		<div
+			class="flex h-10 shrink-0 items-center justify-between gap-4 border-b bg-background/50 px-3 text-xs text-muted-foreground"
+		>
+			<!-- Left: what's being viewed (container + job/pod pickers). -->
+			<div class="flex min-w-0 flex-wrap items-center gap-1">
+				{#if containerControl}
+					{@render containerControl()}
+				{:else}
+					<span class="flex min-w-0 items-center gap-1.5 font-medium text-foreground">
+						<ContainerIcon class="size-3.5 shrink-0 text-muted-foreground" />
+						<span class="truncate">{container}</span>
+					</span>
+				{/if}
+				{#if sourceControls}
+					{@render sourceControls()}
+				{/if}
+			</div>
+			<!-- Right: stream status. -->
+			<div class="flex shrink-0 items-center gap-2">
+				{#if previous}
+					<Badge variant="secondary" class="shrink-0 font-normal">Previous container</Badge>
+				{/if}
+				<span class="flex shrink-0 items-center gap-1.5">
+					<span
+						class={cn(
+							'size-1.5 rounded-full',
+							follow && active ? 'animate-pulse bg-primary' : 'bg-muted-foreground'
+						)}
+					></span>
+					{follow ? 'Streaming' : 'Paused'}
+				</span>
+				<span aria-hidden="true">·</span>
+				<span class="shrink-0">
 					{#if debouncedFilter.trim()}
-						{#each highlightSegments(entry.text, debouncedFilter) as segment, i (i)}
-							{#if segment.hit}<mark class="rounded-sm bg-primary/25 text-inherit"
-									>{segment.text}</mark
-								>{:else}{segment.text}{/if}
-						{/each}
+						{filteredLines.length} of {logLines.length} lines
 					{:else}
-						{entry.text}
+						{logLines.length} lines
 					{/if}
-				</div>
-			{/each}
-		{/if}
-	</div>
-
-	{#if sourceControls}
-		<!-- Source pickers float over the log's top-right corner; clear of the scrollbar. -->
-		<div class="absolute top-2 right-5 flex flex-wrap items-center justify-end gap-2">
-			{@render sourceControls()}
+					{#if droppedLines > 0}
+						· showing last {MAX_LINES}
+					{/if}
+				</span>
+			</div>
 		</div>
-	{/if}
+		<div
+			bind:this={logContainer}
+			onscroll={handleScroll}
+			class="flex-1 overflow-auto py-2 font-mono text-xs leading-relaxed"
+		>
+			{#if logLines.length === 0}
+				<Empty.Root class="h-full">
+					<Empty.Header>
+						<Empty.Media variant="icon">
+							<Spinner />
+						</Empty.Media>
+						<Empty.Title>Waiting for logs</Empty.Title>
+						<Empty.Description>
+							Log data will appear here as soon as the container produces output.
+						</Empty.Description>
+					</Empty.Header>
+				</Empty.Root>
+			{:else if filteredLines.length === 0}
+				<Empty.Root class="h-full">
+					<Empty.Header>
+						<Empty.Media variant="icon">
+							<SearchIcon />
+						</Empty.Media>
+						<Empty.Title>No matching lines</Empty.Title>
+						<Empty.Description>No log lines match "{debouncedFilter}".</Empty.Description>
+					</Empty.Header>
+				</Empty.Root>
+			{:else}
+				{#each filteredLines as entry (entry.no)}
+					<div
+						class={cn(
+							'px-3 hover:bg-muted-foreground/10',
+							wrap ? 'break-all whitespace-pre-wrap' : 'w-fit min-w-full whitespace-pre',
+							entry.text.startsWith('[Error]') && 'text-destructive'
+						)}
+					>
+						{#if debouncedFilter.trim()}
+							{#each highlightSegments(entry.text, debouncedFilter) as segment, i (i)}
+								{#if segment.hit}<mark class="rounded-sm bg-primary/25 text-inherit"
+										>{segment.text}</mark
+									>{:else}{segment.text}{/if}
+							{/each}
+						{:else}
+							{entry.text}
+						{/if}
+					</div>
+				{/each}
+			{/if}
+		</div>
+	</div>
 
 	{#if showScrollButton}
 		<Button
@@ -360,30 +401,4 @@
 			<ArrowDownIcon />
 		</Button>
 	{/if}
-</div>
-
-<!-- Status bar -->
-<div class="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-	<Badge variant="outline" class="gap-1.5 font-normal">
-		<span
-			class={cn(
-				'size-1.5 rounded-full',
-				follow && active ? 'animate-pulse bg-primary' : 'bg-muted-foreground'
-			)}
-		></span>
-		{follow ? 'Streaming' : 'Paused'}
-	</Badge>
-	{#if previous}
-		<Badge variant="secondary" class="font-normal">Previous container</Badge>
-	{/if}
-	<span class="ml-auto">
-		{#if debouncedFilter.trim()}
-			{filteredLines.length} of {logLines.length} lines
-		{:else}
-			{logLines.length} lines
-		{/if}
-		{#if droppedLines > 0}
-			· showing last {MAX_LINES}
-		{/if}
-	</span>
 </div>

--- a/src/lib/components/kind-viewer/kind-viewer-actions/default/log.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/default/log.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { type Transport } from '@connectrpc/connect';
 	import CheckIcon from '@lucide/svelte/icons/check';
+	import ContainerIcon from '@lucide/svelte/icons/container';
 	import CopyIcon from '@lucide/svelte/icons/copy';
 	import DownloadIcon from '@lucide/svelte/icons/download';
 	import HistoryIcon from '@lucide/svelte/icons/history';
@@ -13,6 +14,7 @@
 	import XIcon from '@lucide/svelte/icons/x';
 	import { getContext, type Snippet } from 'svelte';
 
+	import { Badge } from '$lib/components/ui/badge';
 	import { Button } from '$lib/components/ui/button';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import * as InputGroup from '$lib/components/ui/input-group';
@@ -48,11 +50,6 @@
 	let viewer = $state<ReturnType<typeof LogViewer>>();
 
 	const showsPodPicker = $derived(kind !== 'Pod' && resolver.associatedPods.length > 1);
-	const hasPickers = $derived(
-		(kind === 'CronJob' && resolver.associatedJobs.length > 0) ||
-			showsPodPicker ||
-			resolver.containers.length > 1
-	);
 
 	async function handleOpenChange(isOpen: boolean) {
 		if (!isOpen || kind === 'Pod') return;
@@ -67,10 +64,12 @@
 			value={resolver.selectedJob}
 			onValueChange={(value) => resolver.handleJobChange(value)}
 		>
-			<SelectTrigger class="h-8 w-56 bg-background/90 shadow-sm backdrop-blur-sm">
+			<SelectTrigger
+				class="h-7 w-fit max-w-56 gap-1 border-none bg-transparent px-2 text-xs font-medium text-foreground shadow-none hover:bg-accent dark:bg-transparent dark:hover:bg-accent"
+			>
 				<span class="truncate">{resolver.selectedJob || 'Select job'}</span>
 			</SelectTrigger>
-			<SelectContent class="w-(--bits-select-anchor-width) min-w-0">
+			<SelectContent align="start" class="max-w-72 min-w-(--bits-select-anchor-width)">
 				{#each resolver.associatedJobs as j (j)}
 					<SelectItem value={j}>
 						<span class="block truncate">{j}</span>
@@ -85,10 +84,12 @@
 			value={resolver.selectedPod}
 			onValueChange={(value) => (resolver.selectedPod = value)}
 		>
-			<SelectTrigger class="h-8 w-56 bg-background/90 shadow-sm backdrop-blur-sm">
+			<SelectTrigger
+				class="h-7 w-fit max-w-56 gap-1 border-none bg-transparent px-2 text-xs font-medium text-foreground shadow-none hover:bg-accent dark:bg-transparent dark:hover:bg-accent"
+			>
 				<span class="truncate">{resolver.selectedPod || 'Select pod'}</span>
 			</SelectTrigger>
-			<SelectContent class="w-(--bits-select-anchor-width) min-w-0">
+			<SelectContent align="start" class="max-w-72 min-w-(--bits-select-anchor-width)">
 				{#each resolver.associatedPods as p (p)}
 					<SelectItem value={p}>
 						<span class="block truncate">{p}</span>
@@ -97,6 +98,11 @@
 			</SelectContent>
 		</Select>
 	{/if}
+{/snippet}
+
+<!-- The toolbar's leading container label doubles as the container picker when the
+     pod has more than one container; otherwise it's a plain label. -->
+{#snippet containerPicker()}
 	{#if resolver.containers.length > 1}
 		<Select
 			type="single"
@@ -105,17 +111,39 @@
 				if (value) resolver.selectedContainer = value;
 			}}
 		>
-			<SelectTrigger class="h-8 w-44 bg-background/90 shadow-sm backdrop-blur-sm">
-				<span class="truncate">{resolver.selectedContainer || 'Select container'}</span>
+			<SelectTrigger
+				class="-ml-2 h-7 w-fit max-w-64 gap-1 border-none bg-transparent px-2 text-xs font-medium text-foreground shadow-none hover:bg-accent dark:bg-transparent dark:hover:bg-accent"
+			>
+				<span class="flex min-w-0 items-center gap-1.5">
+					<ContainerIcon class="size-3.5 shrink-0 text-muted-foreground" />
+					<span class="truncate">{resolver.selectedContainer || 'Select container'}</span>
+					{#if resolver.initContainerNames.has(resolver.selectedContainer)}
+						<Badge variant="secondary" class="h-4 shrink-0 px-1.5 py-0 text-[10px] font-normal">
+							Init
+						</Badge>
+					{/if}
+				</span>
 			</SelectTrigger>
-			<SelectContent class="w-(--bits-select-anchor-width) min-w-0">
+			<SelectContent align="start" class="max-w-72 min-w-(--bits-select-anchor-width)">
 				{#each resolver.containers as c (c)}
 					<SelectItem value={c}>
-						<span class="block truncate">{c}</span>
+						<span class="flex min-w-0 items-center gap-1.5">
+							<span class="truncate">{c}</span>
+							{#if resolver.initContainerNames.has(c)}
+								<Badge variant="secondary" class="h-4 shrink-0 px-1.5 py-0 text-[10px] font-normal">
+									Init
+								</Badge>
+							{/if}
+						</span>
 					</SelectItem>
 				{/each}
 			</SelectContent>
 		</Select>
+	{:else}
+		<span class="flex min-w-0 items-center gap-1.5 font-medium text-foreground">
+			<ContainerIcon class="size-3.5 shrink-0 text-muted-foreground" />
+			<span class="truncate">{resolver.selectedContainer}</span>
+		</span>
 	{/if}
 {/snippet}
 
@@ -295,7 +323,8 @@
 			podName={resolver.effectivePodName}
 			container={resolver.selectedContainer}
 			active={open}
-			sourceControls={hasPickers ? sourcePickers : undefined}
+			containerControl={containerPicker}
+			sourceControls={sourcePickers}
 		/>
 	</Dialog.Content>
 </Dialog.Root>

--- a/src/lib/components/kind-viewer/kind-viewer-actions/default/pod-resolver.svelte.ts
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/default/pod-resolver.svelte.ts
@@ -10,19 +10,30 @@ interface PodResolverOptions {
 	kind: string;
 }
 
+interface ContainerInfo {
+	name: string;
+	init: boolean;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function extractContainers(obj: any, kind: string): string[] {
+function extractContainers(obj: any, kind: string): ContainerInfo[] {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	let specs: any[] | undefined;
+	let spec: any;
 	if (kind === 'Pod') {
-		specs = obj?.spec?.containers;
+		spec = obj?.spec;
 	} else if (kind === 'CronJob') {
-		specs = obj?.spec?.jobTemplate?.spec?.template?.spec?.containers;
+		spec = obj?.spec?.jobTemplate?.spec?.template?.spec;
 	} else {
-		specs = obj?.spec?.template?.spec?.containers;
+		spec = obj?.spec?.template?.spec;
 	}
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	return specs?.map((c: any) => c.name as string) ?? [];
+	const initContainers: string[] = spec?.initContainers?.map((c: any) => c.name as string) ?? [];
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const containers: string[] = spec?.containers?.map((c: any) => c.name as string) ?? [];
+	return [
+		...initContainers.map((name) => ({ name, init: true })),
+		...containers.map((name) => ({ name, init: false }))
+	];
 }
 
 function toLabelSelector(labels: Record<string, string>): string {
@@ -38,7 +49,11 @@ export function createPodResolver(options: () => PodResolverOptions) {
 	const matchLabels: Record<string, string> = $derived(
 		options().object?.spec?.selector?.matchLabels ?? {}
 	);
-	const containers: string[] = $derived(extractContainers(options().object, options().kind));
+	const containerInfo = $derived(extractContainers(options().object, options().kind));
+	const containers: string[] = $derived(containerInfo.map((c) => c.name));
+	const initContainerNames = $derived(
+		new SvelteSet(containerInfo.filter((c) => c.init).map((c) => c.name))
+	);
 
 	let associatedJobs = $state<string[]>([]);
 	let selectedJob = $state('');
@@ -216,6 +231,9 @@ export function createPodResolver(options: () => PodResolverOptions) {
 		},
 		get containers() {
 			return containers;
+		},
+		get initContainerNames() {
+			return initContainerNames;
 		},
 		get effectivePodName() {
 			return effectivePodName;

--- a/src/lib/components/kind-viewer/kind-viewer-actions/default/terminal.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/default/terminal.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
 	import { type Transport } from '@connectrpc/connect';
+	import ContainerIcon from '@lucide/svelte/icons/container';
 	import TerminalSquareIcon from '@lucide/svelte/icons/terminal-square';
 	import { getContext, type Snippet } from 'svelte';
 
 	import { Terminal } from '$lib/components/applications/terminal';
+	import { Badge } from '$lib/components/ui/badge';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import * as Item from '$lib/components/ui/item';
 	import { Select, SelectContent, SelectItem, SelectTrigger } from '$lib/components/ui/select';
-	import { cn } from '$lib/utils';
 
 	import { ACTION_DIALOG_CONTENT_FIT_CLASS } from './constants';
 	import { createPodResolver } from './pod-resolver.svelte';
@@ -32,12 +33,6 @@
 
 	let open = $state(false);
 	let showTerminal = $state(false);
-
-	const hasPickers = $derived(
-		(kind === 'CronJob' && resolver.associatedJobs.length > 0) ||
-			(kind !== 'Pod' && resolver.associatedPods.length > 1) ||
-			resolver.containers.length > 1
-	);
 
 	async function handleOpenChange(isOpen: boolean) {
 		if (isOpen) {
@@ -76,28 +71,61 @@
 			</div>
 		</Dialog.Header>
 
-		<div
-			class={cn(
-				'relative h-[55vh] overflow-hidden rounded-md border bg-[#1e1e1e] p-3',
-				// Floating pickers overlay the box's top-right; pad the shell clear of them.
-				hasPickers && 'pt-12'
-			)}
-		>
-			{#if showTerminal && resolver.selectedContainer && resolver.effectivePodName}
-				{#key `${resolver.effectivePodName}-${resolver.selectedContainer}`}
-					<Terminal
-						{cluster}
-						namespace={resolver.namespace}
-						podName={resolver.effectivePodName}
-						containerName={resolver.selectedContainer}
-						command={['/bin/sh']}
-					/>
-				{/key}
-			{/if}
-
-			<!-- Source pickers float over the terminal's top-right corner. -->
-			{#if hasPickers}
-				<div class="absolute top-2 right-5 flex flex-wrap items-center justify-end gap-2">
+		<div class="flex h-[55vh] flex-col overflow-hidden rounded-md border">
+			<!-- In-frame toolbar, same layout as the log viewer: sources on the left.
+			     Fixed h-10 keeps the height identical with or without pickers. -->
+			<div
+				class="flex h-10 shrink-0 items-center justify-between gap-4 border-b bg-background/50 px-3 text-xs text-muted-foreground"
+			>
+				<div class="flex min-w-0 flex-wrap items-center gap-1">
+					{#if resolver.containers.length > 1}
+						<Select
+							type="single"
+							value={resolver.selectedContainer}
+							onValueChange={(value) => {
+								if (value) resolver.selectedContainer = value;
+							}}
+						>
+							<SelectTrigger
+								class="-ml-2 h-7 w-fit max-w-64 gap-1 border-none bg-transparent px-2 text-xs font-medium text-foreground shadow-none hover:bg-accent dark:bg-transparent dark:hover:bg-accent"
+							>
+								<span class="flex min-w-0 items-center gap-1.5">
+									<ContainerIcon class="size-3.5 shrink-0 text-muted-foreground" />
+									<span class="truncate">{resolver.selectedContainer || 'Select container'}</span>
+									{#if resolver.initContainerNames.has(resolver.selectedContainer)}
+										<Badge
+											variant="secondary"
+											class="h-4 shrink-0 px-1.5 py-0 text-[10px] font-normal"
+										>
+											Init
+										</Badge>
+									{/if}
+								</span>
+							</SelectTrigger>
+							<SelectContent align="start" class="max-w-72 min-w-(--bits-select-anchor-width)">
+								{#each resolver.containers as c (c)}
+									<SelectItem value={c}>
+										<span class="flex min-w-0 items-center gap-1.5">
+											<span class="truncate">{c}</span>
+											{#if resolver.initContainerNames.has(c)}
+												<Badge
+													variant="secondary"
+													class="h-4 shrink-0 px-1.5 py-0 text-[10px] font-normal"
+												>
+													Init
+												</Badge>
+											{/if}
+										</span>
+									</SelectItem>
+								{/each}
+							</SelectContent>
+						</Select>
+					{:else}
+						<span class="flex min-w-0 items-center gap-1.5 font-medium text-foreground">
+							<ContainerIcon class="size-3.5 shrink-0 text-muted-foreground" />
+							<span class="truncate">{resolver.selectedContainer}</span>
+						</span>
+					{/if}
 					{#if kind === 'CronJob' && resolver.associatedJobs.length > 0}
 						<Select
 							type="single"
@@ -106,10 +134,12 @@
 								await resolver.handleJobChange(value);
 							}}
 						>
-							<SelectTrigger class="h-8 w-56 bg-background/90 shadow-sm backdrop-blur-sm">
+							<SelectTrigger
+								class="h-7 w-fit max-w-56 gap-1 border-none bg-transparent px-2 text-xs font-medium text-foreground shadow-none hover:bg-accent dark:bg-transparent dark:hover:bg-accent"
+							>
 								<span class="truncate">{resolver.selectedJob || 'Select job'}</span>
 							</SelectTrigger>
-							<SelectContent class="w-(--bits-select-anchor-width) min-w-0">
+							<SelectContent align="start" class="max-w-72 min-w-(--bits-select-anchor-width)">
 								{#each resolver.associatedJobs as j (j)}
 									<SelectItem value={j}>
 										<span class="block truncate">{j}</span>
@@ -126,10 +156,12 @@
 								resolver.selectedPod = value;
 							}}
 						>
-							<SelectTrigger class="h-8 w-56 bg-background/90 shadow-sm backdrop-blur-sm">
+							<SelectTrigger
+								class="h-7 w-fit max-w-56 gap-1 border-none bg-transparent px-2 text-xs font-medium text-foreground shadow-none hover:bg-accent dark:bg-transparent dark:hover:bg-accent"
+							>
 								<span class="truncate">{resolver.selectedPod || 'Select pod'}</span>
 							</SelectTrigger>
-							<SelectContent class="w-(--bits-select-anchor-width) min-w-0">
+							<SelectContent align="start" class="max-w-72 min-w-(--bits-select-anchor-width)">
 								{#each resolver.associatedPods as p (p)}
 									<SelectItem value={p}>
 										<span class="block truncate">{p}</span>
@@ -138,28 +170,22 @@
 							</SelectContent>
 						</Select>
 					{/if}
-					{#if resolver.containers.length > 1}
-						<Select
-							type="single"
-							value={resolver.selectedContainer}
-							onValueChange={(value) => {
-								if (value) resolver.selectedContainer = value;
-							}}
-						>
-							<SelectTrigger class="h-8 w-44 bg-background/90 shadow-sm backdrop-blur-sm">
-								<span class="truncate">{resolver.selectedContainer || 'Select container'}</span>
-							</SelectTrigger>
-							<SelectContent class="w-(--bits-select-anchor-width) min-w-0">
-								{#each resolver.containers as c (c)}
-									<SelectItem value={c}>
-										<span class="block truncate">{c}</span>
-									</SelectItem>
-								{/each}
-							</SelectContent>
-						</Select>
-					{/if}
 				</div>
-			{/if}
+			</div>
+
+			<div class="min-h-0 flex-1 bg-[#1e1e1e] p-3">
+				{#if showTerminal && resolver.selectedContainer && resolver.effectivePodName}
+					{#key `${resolver.effectivePodName}-${resolver.selectedContainer}`}
+						<Terminal
+							{cluster}
+							namespace={resolver.namespace}
+							podName={resolver.effectivePodName}
+							containerName={resolver.selectedContainer}
+							command={['/bin/sh']}
+						/>
+					{/key}
+				{/if}
+			</div>
 		</div>
 	</Dialog.Content>
 </Dialog.Root>


### PR DESCRIPTION
Replace the floating top-right picker overlay in log-viewer and terminal with a fixed-height in-frame toolbar, so pickers no longer need conditional padding hacks or a hasPickers derived to size around themselves. The log-viewer's status bar (streaming indicator, previous container badge, line count) moves into the same toolbar, on the right.

- pod-resolver: track init containers separately via initContainerNames, so pickers can badge them as "Init"
- log/terminal: container select becomes a containerControl snippet that's a plain label when there's only one container, and shows an "Init" badge per option/selection when applicable
- restyle picker SelectTriggers as inline toolbar buttons (ghost, text-sized) instead of floating backdrop-blur badges