### PR TITLE
fix(kind-viewer): disable namespaced InstanceType in favor of Cluster…

### DIFF
--- a/src/lib/components/kind-viewer/kind-viewer-actions/index.ts
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/index.ts
@@ -20,8 +20,9 @@ import DeploymentActions from './deployment/actions.svelte';
 import HelmReleaseActions from './helm-release/actions.svelte';
 import HelmRepositoryActions from './helm-repository/actions.svelte';
 import HelmRepositoryCreate from './helm-repository/create.svelte';
-import InstanceTypeActions from './instance-type/actions.svelte';
-import InstanceTypeCreate from './instance-type/create.svelte';
+// Namespaced InstanceType is disabled — most users use ClusterInstanceType directly.
+// import InstanceTypeActions from './instance-type/actions.svelte';
+// import InstanceTypeCreate from './instance-type/create.svelte';
 import JobActions from './job/actions.svelte';
 import LLMInferenceServiceActions from './llm-inference-service/actions.svelte';
 import LLMInferenceServiceConfigActions from './llm-inference-service-config/actions.svelte';
@@ -96,8 +97,8 @@ function getCreate(kind: string, namespace?: string): CreateType {
 			return TaskCreate as CreateType;
 		case 'VirtualMachine':
 			return VirtualMachineCreate as CreateType;
-		case 'VirtualMachineInstancetype':
-			return InstanceTypeCreate as CreateType;
+		// case 'VirtualMachineInstancetype':
+		// 	return InstanceTypeCreate as CreateType;
 		case 'Workspace':
 			return WorkspaceCreate as CreateType;
 		case 'LLMInferenceServiceConfig':
@@ -153,8 +154,8 @@ function getActions(kind: string, namespace?: string): ActionsType {
 			return TaskActions as ActionsType;
 		case 'VirtualMachine':
 			return VirtualMachineActions as ActionsType;
-		case 'VirtualMachineInstancetype':
-			return InstanceTypeActions as ActionsType;
+		// case 'VirtualMachineInstancetype':
+		// 	return InstanceTypeActions as ActionsType;
 		case 'Workspace':
 			return WorkspaceActions as ActionsType;
 		default:

--- a/src/lib/components/kind-viewer/kind-viewer-actions/virtual-machine/create.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/virtual-machine/create.svelte
@@ -65,7 +65,9 @@
 			metadata: { name: '' },
 			spec: {
 				instancetype: {
-					kind: 'VirtualMachineInstancetype' as string,
+					// Namespaced InstanceType is disabled — most users use ClusterInstanceType directly.
+					// kind: 'VirtualMachineInstancetype' as string,
+					kind: 'VirtualMachineClusterInstancetype' as string,
 					name: null as string | null
 				}
 			},
@@ -237,7 +239,9 @@
 	let value = $derived(stringify(submissionValues));
 
 	// Steps Manager
-	const steps = Array.from({ length: 9 }, (_, index) => String(index + 1));
+	// 9 steps when the Instance Type Kind step is enabled.
+	// const steps = Array.from({ length: 9 }, (_, index) => String(index + 1));
+	const steps = Array.from({ length: 8 }, (_, index) => String(index + 1));
 	const [firstStep] = steps;
 	let currentStep = $state(firstStep);
 	const currentIndex = $derived(steps.indexOf(currentStep));
@@ -277,17 +281,19 @@
 		search: string
 	): Promise<{ label: string; value: string }[]> {
 		try {
-			const itKind = values.spec.instancetype.kind;
-			if (!itKind) return [];
-			const isClusterScoped = itKind === 'VirtualMachineClusterInstancetype';
+			// Namespaced InstanceType is disabled — always list cluster-scoped instance types.
+			// const itKind = values.spec.instancetype.kind;
+			// if (!itKind) return [];
+			// const isClusterScoped = itKind === 'VirtualMachineClusterInstancetype';
 			const response = await resourceClient.list({
 				cluster,
 				group: 'instancetype.kubevirt.io',
 				version: 'v1beta1',
-				resource: isClusterScoped
-					? 'virtualmachineclusterinstancetypes'
-					: 'virtualmachineinstancetypes',
-				...(isClusterScoped ? {} : { namespace })
+				// resource: isClusterScoped
+				// 	? 'virtualmachineclusterinstancetypes'
+				// 	: 'virtualmachineinstancetypes',
+				// ...(isClusterScoped ? {} : { namespace })
+				resource: 'virtualmachineclusterinstancetypes'
 			});
 			return response.items
 				.map((item) => {
@@ -370,7 +376,7 @@
 		try {
 			let gpuResourcesList: string[];
 
-			// If a node is selected in step 6, fetch GPU resources only for that node
+			// If a node is selected in step 5, fetch GPU resources only for that node
 			if (nodeSelector.node) {
 				gpuResourcesList = await fetchGpuResourcesForNode(nodeSelector.node);
 			} else {
@@ -541,7 +547,8 @@
 					{/snippet}
 				</Form>
 			</Tabs.Content>
-			<!-- Step 2: Instance Type Kind -->
+			<!-- Step (removed): Instance Type Kind — namespaced InstanceType is disabled.
+				Re-enable by restoring this block, bumping `steps` back to 9, and shifting later step indices.
 			<Tabs.Content value={steps[1]}>
 				<Form
 					schema={{
@@ -583,8 +590,9 @@
 					{/snippet}
 				</Form>
 			</Tabs.Content>
-			<!-- Step 3: Instance Type -->
-			<Tabs.Content value={steps[2]}>
+			-->
+			<!-- Step 2: Instance Type -->
+			<Tabs.Content value={steps[1]}>
 				<Form
 					schema={{
 						...(lodash.get(jsonSchema, 'properties.spec.properties.instancetype.properties.name', {
@@ -632,8 +640,8 @@
 					{/snippet}
 				</Form>
 			</Tabs.Content>
-			<!-- Step 4: Disk Source Type -->
-			<Tabs.Content value={steps[3]}>
+			<!-- Step 3: Disk Source Type -->
+			<Tabs.Content value={steps[2]}>
 				<Form
 					schema={{
 						type: 'string',
@@ -673,8 +681,8 @@
 					{/snippet}
 				</Form>
 			</Tabs.Content>
-			<!-- Step 5: Disks -->
-			<Tabs.Content value={steps[4]}>
+			<!-- Step 4: Disks -->
+			<Tabs.Content value={steps[3]}>
 				{#if values.diskSourceType === 'containerDisk'}
 					<Form
 						schema={{
@@ -844,8 +852,8 @@
 					</Form>
 				{/if}
 			</Tabs.Content>
-			<!-- Step 6: Node Selector -->
-			<Tabs.Content value={steps[5]}>
+			<!-- Step 5: Node Selector -->
+			<Tabs.Content value={steps[4]}>
 				<Form
 					schema={{
 						type: 'object',
@@ -902,8 +910,8 @@
 					{/snippet}
 				</Form>
 			</Tabs.Content>
-			<!-- Step 7: GPU Passthrough -->
-			<Tabs.Content value={steps[6]}>
+			<!-- Step 6: GPU Passthrough -->
+			<Tabs.Content value={steps[5]}>
 				<Form
 					schema={{
 						type: 'object',
@@ -988,8 +996,8 @@
 					{/snippet}
 				</Form>
 			</Tabs.Content>
-			<!-- Step 8: Cloud-Init -->
-			<Tabs.Content value={steps[7]}>
+			<!-- Step 7: Cloud-Init -->
+			<Tabs.Content value={steps[6]}>
 				<Form
 					schema={{
 						type: 'string',
@@ -1027,8 +1035,8 @@
 					{/snippet}
 				</Form>
 			</Tabs.Content>
-			<!-- Step 9: Review & Create -->
-			<Tabs.Content value={steps[8]} class="min-h-[77vh]">
+			<!-- Step 8: Review & Create -->
+			<Tabs.Content value={steps[7]} class="min-h-[77vh]">
 				<div class="flex h-full flex-col gap-3">
 					<Monaco
 						options={{

--- a/src/lib/components/kind-viewer/kind-viewer-actions/virtual-machine/update.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/virtual-machine/update.svelte
@@ -79,7 +79,9 @@
 			spec: {
 				runStrategy: (object.spec?.runStrategy ?? 'Halted') as string,
 				instancetype: {
-					kind: (object.spec?.instancetype?.kind ?? 'VirtualMachineInstancetype') as string,
+					// Namespaced InstanceType is disabled — most users use ClusterInstanceType directly.
+					// kind: (object.spec?.instancetype?.kind ?? 'VirtualMachineInstancetype') as string,
+					kind: (object.spec?.instancetype?.kind ?? 'VirtualMachineClusterInstancetype') as string,
 					name: (object.spec?.instancetype?.name ?? null) as string | null
 				}
 			},
@@ -247,7 +249,9 @@
 	let value = $derived(stringify(submissionValues));
 
 	// Steps Manager
-	const steps = Array.from({ length: 7 }, (_, index) => String(index + 1));
+	// 7 steps when the Instance Type Kind step is enabled.
+	// const steps = Array.from({ length: 7 }, (_, index) => String(index + 1));
+	const steps = Array.from({ length: 6 }, (_, index) => String(index + 1));
 	const [firstStep] = steps;
 	let currentStep = $state(firstStep);
 	const currentIndex = $derived(steps.indexOf(currentStep));
@@ -378,7 +382,7 @@
 		try {
 			let gpuResourcesList: string[];
 
-			// If a node is selected in step 4, fetch GPU resources only for that node
+			// If a node is selected in step 3, fetch GPU resources only for that node
 			if (nodeSelector.node) {
 				gpuResourcesList = await fetchGpuResourcesForNode(nodeSelector.node);
 			} else {
@@ -498,7 +502,9 @@
 			</Item.Content>
 		</Item.Root>
 		<Tabs.Root value={currentStep} class="*:data-[slot=tabs-content]:min-h-[50vh]">
-			<!-- Step 1: Instance Type Kind -->
+			<!-- Step (removed): Instance Type Kind — namespaced InstanceType is disabled.
+				Re-enable by restoring this block, bumping `steps` back to 7, shifting later step indices,
+				and adding the Previous button back to the Instance Type step below.
 			<Tabs.Content value={steps[0]}>
 				<Form
 					schema={{
@@ -533,8 +539,9 @@
 					{/snippet}
 				</Form>
 			</Tabs.Content>
-			<!-- Step 2: Instance Type -->
-			<Tabs.Content value={steps[1]}>
+			-->
+			<!-- Step 1: Instance Type -->
+			<Tabs.Content value={steps[0]}>
 				<Form
 					schema={{
 						...(lodash.get(jsonSchema, 'properties.spec.properties.instancetype.properties.name', {
@@ -569,21 +576,14 @@
 					bind:values={values['spec']['instancetype']['name']}
 				>
 					{#snippet actions()}
-						<div class="flex w-full items-center justify-between gap-3">
-							<Button
-								onclick={() => {
-									handlePrevious();
-								}}
-							>
-								Previous
-							</Button>
+						<div class="flex w-full items-center justify-end gap-3">
 							<SubmitButton />
 						</div>
 					{/snippet}
 				</Form>
 			</Tabs.Content>
-			<!-- Step 3: Additional Disks -->
-			<Tabs.Content value={steps[2]}>
+			<!-- Step 2: Additional Disks -->
+			<Tabs.Content value={steps[1]}>
 				<Form
 					schema={{
 						type: 'array',
@@ -639,8 +639,8 @@
 					{/snippet}
 				</Form>
 			</Tabs.Content>
-			<!-- Step 4: Node Selector -->
-			<Tabs.Content value={steps[3]}>
+			<!-- Step 3: Node Selector -->
+			<Tabs.Content value={steps[2]}>
 				<Form
 					schema={{
 						type: 'object',
@@ -697,8 +697,8 @@
 					{/snippet}
 				</Form>
 			</Tabs.Content>
-			<!-- Step 5: GPU Passthrough -->
-			<Tabs.Content value={steps[4]}>
+			<!-- Step 4: GPU Passthrough -->
+			<Tabs.Content value={steps[3]}>
 				<Form
 					schema={{
 						type: 'object',
@@ -783,8 +783,8 @@
 					{/snippet}
 				</Form>
 			</Tabs.Content>
-			<!-- Step 6: Cloud-Init -->
-			<Tabs.Content value={steps[5]}>
+			<!-- Step 5: Cloud-Init -->
+			<Tabs.Content value={steps[4]}>
 				<Form
 					schema={{
 						type: 'string',
@@ -823,8 +823,8 @@
 					{/snippet}
 				</Form>
 			</Tabs.Content>
-			<!-- Step 7: Review & Edit -->
-			<Tabs.Content value={steps[6]}>
+			<!-- Step 6: Review & Edit -->
+			<Tabs.Content value={steps[5]}>
 				<div class="flex h-full flex-col gap-3">
 					<Monaco
 						options={{

--- a/src/lib/components/kind-viewer/kind-viewer-columns/index.ts
+++ b/src/lib/components/kind-viewer/kind-viewer-columns/index.ts
@@ -100,12 +100,13 @@ import {
 	getHTTPRouteDataSchemas,
 	getHTTPRouteUISchemas
 } from './httproute.js';
-import {
-	getVirtualMachineInstancetypeColumnDefinitions,
-	getVirtualMachineInstancetypeData,
-	getVirtualMachineInstancetypeDataSchemas,
-	getVirtualMachineInstancetypeUISchemas
-} from './instancetype.js';
+// Namespaced InstanceType is disabled — most users use ClusterInstanceType directly.
+// import {
+// 	getVirtualMachineInstancetypeColumnDefinitions,
+// 	getVirtualMachineInstancetypeData,
+// 	getVirtualMachineInstancetypeDataSchemas,
+// 	getVirtualMachineInstancetypeUISchemas
+// } from './instancetype.js';
 import { getJobColumnDefinitions, getJobData, getJobDataSchemas, getJobUISchemas } from './job.js';
 import {
 	getLimitRangeColumnDefinitions,
@@ -293,8 +294,8 @@ function getDataSchemas(kind: string): Record<string, DataSchemaType> {
 			return getVirtualMachineDataSchemas();
 		case 'DataVolume':
 			return getDataVolumeDataSchemas();
-		case 'VirtualMachineInstancetype':
-			return getVirtualMachineInstancetypeDataSchemas();
+		// case 'VirtualMachineInstancetype':
+		// 	return getVirtualMachineInstancetypeDataSchemas();
 		case 'ObjectBucketClaim':
 			return getObjectBucketClaimDataSchemas();
 		case 'Application':
@@ -379,8 +380,8 @@ function getData(apiResource: APIResource, object: JsonObject): Record<string, J
 			return getVirtualMachineData(resource);
 		case 'DataVolume':
 			return getDataVolumeData(resource);
-		case 'VirtualMachineInstancetype':
-			return getVirtualMachineInstancetypeData(resource);
+		// case 'VirtualMachineInstancetype':
+		// 	return getVirtualMachineInstancetypeData(resource);
 		case 'ObjectBucketClaim':
 			return getObjectBucketClaimData(resource);
 		case 'Application':
@@ -462,8 +463,8 @@ function getUISchemas(kind: string): Record<string, UISchemaType> {
 			return getVirtualMachineUISchemas();
 		case 'DataVolume':
 			return getDataVolumeUISchemas();
-		case 'VirtualMachineInstancetype':
-			return getVirtualMachineInstancetypeUISchemas();
+		// case 'VirtualMachineInstancetype':
+		// 	return getVirtualMachineInstancetypeUISchemas();
 		case 'ObjectBucketClaim':
 			return getObjectBucketClaimUISchemas();
 		case 'Application':
@@ -550,8 +551,8 @@ function getColumnDefinitions(
 			return getVirtualMachineColumnDefinitions(apiResource, uiSchemas, dataSchemas, cluster);
 		case 'DataVolume':
 			return getDataVolumeColumnDefinitions(apiResource, uiSchemas, dataSchemas);
-		case 'VirtualMachineInstancetype':
-			return getVirtualMachineInstancetypeColumnDefinitions(apiResource, uiSchemas, dataSchemas);
+		// case 'VirtualMachineInstancetype':
+		// 	return getVirtualMachineInstancetypeColumnDefinitions(apiResource, uiSchemas, dataSchemas);
 		case 'ObjectBucketClaim':
 			return getObjectBucketClaimColumnDefinitions(apiResource, uiSchemas, dataSchemas);
 		case 'Application':

--- a/src/lib/components/kind-viewer/kind-viewer-columns/virtualmachine.ts
+++ b/src/lib/components/kind-viewer/kind-viewer-columns/virtualmachine.ts
@@ -49,8 +49,10 @@ function getVirtualMachineData(
 	object: KubevirtIoV1VirtualMachine
 ): Record<VirtualMachineAttribute, JsonValue> {
 	const instancetype = object?.spec?.instancetype;
+	// Namespaced InstanceType is disabled — fall back to the cluster-scoped kind.
+	// ? `${instancetype.kind ?? 'VirtualMachineInstancetype'}/${instancetype.name}`
 	const instanceTypeDisplay = instancetype
-		? `${instancetype.kind ?? 'VirtualMachineInstancetype'}/${instancetype.name}`
+		? `${instancetype.kind ?? 'VirtualMachineClusterInstancetype'}/${instancetype.name}`
 		: null;
 
 	return {

--- a/src/routes/(auth)/+layout.svelte
+++ b/src/routes/(auth)/+layout.svelte
@@ -359,16 +359,17 @@
 							kind: 'DataVolume',
 							resource: 'datavolumes'
 						})
-					},
-					{
-						title: m.instance_type(),
-						url: resourceUrl({
-							group: 'instancetype.kubevirt.io',
-							version: 'v1beta1',
-							kind: 'VirtualMachineInstancetype',
-							resource: 'virtualmachineinstancetypes'
-						})
 					}
+					// Namespaced InstanceType is disabled — most users use ClusterInstanceType directly.
+					// {
+					// 	title: m.instance_type(),
+					// 	url: resourceUrl({
+					// 		group: 'instancetype.kubevirt.io',
+					// 		version: 'v1beta1',
+					// 		kind: 'VirtualMachineInstancetype',
+					// 		resource: 'virtualmachineinstancetypes'
+					// 	})
+					// }
 				]
 			},
 			{


### PR DESCRIPTION
…InstanceType

Most users create instance types at the cluster scope, so the namespaced VirtualMachineInstancetype kind/routes/wizard step are commented out (not deleted) and default to VirtualMachineClusterInstancetype.