### PR TITLE
feat(i18n): add Enterprise Edition CTA copy to about dialog strings

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -6,6 +6,8 @@
 	"slogan": "One Platform, Infinite Possibilities.",
 	"join_1": "Join our community",
 	"join_2": "of designers & developers",
+	"join_3": "Ready to scale further",
+	"join_4": "Discover OtterScale Enterprise Edition",
 	"privacy_policy": "Privacy Policy",
 	"terms_of_service": "Terms of Service",
 	"go_back": "Go Back",

--- a/messages/zh-hant.json
+++ b/messages/zh-hant.json
@@ -6,6 +6,8 @@
 	"slogan": "單一平台，無限可能。",
 	"join_1": "加入我們的社群",
 	"join_2": "與設計師和開發者一起",
+	"join_3": "準備好進一步擴展",
+	"join_4": "探索 OtterScale 企業版",
 	"privacy_policy": "隱私權政策",
 	"terms_of_service": "服務條款",
 	"go_back": "返回",


### PR DESCRIPTION
Add join_3/join_4 message keys (English and Traditional Chinese) as a second tagline pair promoting OtterScale Enterprise Edition.