### PR TITLE
feat(helm-release): add upgrade action with values diff review

### DIFF
--- a/src/lib/components/artifact-viewer/artifact-viewer-actions/install-from-harbor.svelte
+++ b/src/lib/components/artifact-viewer/artifact-viewer-actions/install-from-harbor.svelte
@@ -23,6 +23,7 @@
 	import * as Empty from '$lib/components/ui/empty/index.js';
 	import * as Item from '$lib/components/ui/item';
 	import * as Tabs from '$lib/components/ui/tabs/index.js';
+	import { computeValuesDelta } from '$lib/utils/helm-values';
 
 	import type { ChartAttribute } from '../table-layout';
 	import { type ArtifactChartType } from '../types';
@@ -400,7 +401,13 @@
 								const raw = lodash.get(values, 'spec.values');
 								if (typeof raw !== 'string') return;
 								try {
-									lodash.set(values, 'spec.values', parse(raw) ?? {});
+									const defaultValues = parse(String(documents.values));
+
+									lodash.set(
+										values,
+										'spec.values',
+										computeValuesDelta(defaultValues, parse(raw) ?? {})
+									);
 								} catch (error) {
 									console.error('Failed to load values:', error);
 									toast.error('Failed to load values');

--- a/src/lib/components/artifact-viewer/artifact-viewer-actions/install-from-index.svelte
+++ b/src/lib/components/artifact-viewer/artifact-viewer-actions/install-from-index.svelte
@@ -24,6 +24,7 @@
 	import * as Empty from '$lib/components/ui/empty/index.js';
 	import * as Item from '$lib/components/ui/item';
 	import * as Tabs from '$lib/components/ui/tabs/index.js';
+	import { computeValuesDelta } from '$lib/utils/helm-values';
 
 	import type { ChartAttribute } from '../table-layout';
 	import { type IndexChartType } from '../types';
@@ -332,8 +333,13 @@
 								handleNext();
 								try {
 									const structuredValues = load(lodash.get(values, 'spec.values') as string);
+									const defaultValues = load(documents.values);
 
-									lodash.set(values, 'spec.values', structuredValues);
+									lodash.set(
+										values,
+										'spec.values',
+										computeValuesDelta(defaultValues, structuredValues)
+									);
 								} catch (error) {
 									console.error('Failed to load values:', error);
 									toast.error('Failed to load values');

--- a/src/lib/components/custom/monaco-diff/index.ts
+++ b/src/lib/components/custom/monaco-diff/index.ts
@@ -1,0 +1,3 @@
+import MonacoDiff from './monaco-diff.svelte';
+
+export { MonacoDiff };

--- a/src/lib/components/custom/monaco-diff/monaco-diff.svelte
+++ b/src/lib/components/custom/monaco-diff/monaco-diff.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+	import loader from '@monaco-editor/loader';
+	import type MonacoE from 'monaco-editor';
+	import { onDestroy, onMount } from 'svelte';
+
+	let {
+		original,
+		modified = $bindable(),
+		language = 'yaml',
+		theme = 'vs',
+		renderSideBySide = true,
+		hideUnchanged = false,
+		options = {}
+	}: {
+		original: string;
+		modified: string;
+		language?: string;
+		theme?: string;
+		renderSideBySide?: boolean;
+		hideUnchanged?: boolean;
+		options?: MonacoE.editor.IDiffEditorConstructionOptions;
+	} = $props();
+
+	let container: HTMLDivElement | undefined = $state();
+	let monaco = $state<typeof MonacoE>();
+	let editor = $state<MonacoE.editor.IStandaloneDiffEditor>();
+	let originalModel = $state<MonacoE.editor.ITextModel>();
+	let modifiedModel = $state<MonacoE.editor.ITextModel>();
+	let layoutTimeout: ReturnType<typeof setTimeout> | undefined;
+	let disposed = false;
+
+	onMount(async () => {
+		const monacoInstance = await loader.init();
+
+		const createdOriginal = monacoInstance.editor.createModel(original, language);
+		const createdModified = monacoInstance.editor.createModel(modified, language);
+
+		const diffEditor = monacoInstance.editor.createDiffEditor(container!, {
+			automaticLayout: true,
+			originalEditable: false,
+			renderSideBySide,
+			hideUnchangedRegions: { enabled: hideUnchanged },
+			scrollBeyondLastLine: false,
+			...options
+		});
+		diffEditor.setModel({ original: createdOriginal, modified: createdModified });
+		monacoInstance.editor.setTheme(theme);
+
+		createdModified.onDidChangeContent(() => {
+			modified = createdModified.getValue();
+		});
+
+		// The dialog's open animation transforms the container while the editor
+		// measures itself; re-layout once the animation has settled.
+		requestAnimationFrame(() => {
+			if (!disposed) diffEditor.layout();
+		});
+		layoutTimeout = setTimeout(() => {
+			if (!disposed) diffEditor.layout();
+		}, 300);
+
+		monaco = monacoInstance;
+		originalModel = createdOriginal;
+		modifiedModel = createdModified;
+		editor = diffEditor;
+	});
+
+	$effect(() => {
+		if (theme) monaco?.editor.setTheme(theme);
+	});
+
+	$effect(() => {
+		editor?.updateOptions({ renderSideBySide });
+	});
+
+	$effect(() => {
+		editor?.updateOptions({ hideUnchangedRegions: { enabled: hideUnchanged } });
+	});
+
+	$effect(() => {
+		if (originalModel && originalModel.getValue() !== original) {
+			originalModel.setValue(original);
+		}
+	});
+
+	$effect(() => {
+		if (modifiedModel && modifiedModel.getValue() !== modified) {
+			modifiedModel.setValue(modified);
+		}
+	});
+
+	onDestroy(() => {
+		disposed = true;
+		clearTimeout(layoutTimeout);
+		editor?.dispose();
+		originalModel?.dispose();
+		modifiedModel?.dispose();
+	});
+</script>
+
+<div class="h-full w-full" bind:this={container}></div>

--- a/src/lib/components/kind-viewer/kind-viewer-actions/helm-release/actions.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/helm-release/actions.svelte
@@ -11,7 +11,7 @@
 	import Button from '$lib/components/ui/button/button.svelte';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu/index.js';
 
-	// import Update from './update.svelte';
+	import Upgrade from './upgrade.svelte';
 
 	let {
 		schema,
@@ -84,21 +84,25 @@
 					}}
 				/>
 			</DropdownMenu.Item>
-			<!-- <DropdownMenu.Item
+			<DropdownMenu.Item
 				onSelect={(e) => {
 					e.preventDefault();
 				}}
 			>
-				<Update
+				<Upgrade
 					{cluster}
 					{namespace}
-					{schema}
+					{group}
+					{version}
+					{kind}
+					{resource}
+					{validate}
 					{object}
 					onOpenChangeComplete={() => {
 						actionsOpen = false;
 					}}
 				/>
-			</DropdownMenu.Item> -->
+			</DropdownMenu.Item>
 			<DropdownMenu.Item
 				onSelect={(e) => {
 					e.preventDefault();

--- a/src/lib/components/kind-viewer/kind-viewer-actions/helm-release/upgrade.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/helm-release/upgrade.svelte
@@ -1,0 +1,548 @@
+<script lang="ts">
+	import { ConnectError, createClient, type Transport } from '@connectrpc/connect';
+	import ArrowUpCircleIcon from '@lucide/svelte/icons/arrow-up-circle';
+	import Columns2Icon from '@lucide/svelte/icons/columns-2';
+	import FileIcon from '@lucide/svelte/icons/file';
+	import FoldVerticalIcon from '@lucide/svelte/icons/fold-vertical';
+	import { ResourceService } from '@otterscale/api/resource/v1';
+	import { RuntimeService } from '@otterscale/api/runtime/v1';
+	import type {
+		HelmToolkitFluxcdIoV2HelmRelease,
+		SourceToolkitFluxcdIoV1HelmRepository
+	} from '@otterscale/types';
+	import type { FormState, FormValue, Schema, UiSchemaRoot } from '@sjsf/form';
+	import { getValueSnapshot, SubmitButton } from '@sjsf/form';
+	import { type ValidateFunction } from 'ajv';
+	import { JSON_SCHEMA, load } from 'js-yaml';
+	import lodash from 'lodash';
+	import { mode as themeMode } from 'mode-watcher';
+	import { getContext } from 'svelte';
+	import { toast } from 'svelte-sonner';
+	import { parse, stringify } from 'yaml';
+
+	import type { ArtifactChartType, ChartType } from '$lib/components/artifact-viewer/types';
+	import {
+		encodeHarborURIComponent,
+		parseHarborHost,
+		parseHarborProjectName
+	} from '$lib/components/artifact-viewer/utils.svelte';
+	import { MonacoDiff } from '$lib/components/custom/monaco-diff';
+	import Form from '$lib/components/dynamic-form/form.svelte';
+	import Button from '$lib/components/ui/button/button.svelte';
+	import * as Dialog from '$lib/components/ui/dialog';
+	import * as Empty from '$lib/components/ui/empty/index.js';
+	import * as Item from '$lib/components/ui/item';
+	import { Spinner } from '$lib/components/ui/spinner';
+	import { Toggle } from '$lib/components/ui/toggle';
+	import * as Tooltip from '$lib/components/ui/tooltip';
+	import { applyDeltaToYamlText, computeValuesDelta } from '$lib/utils/helm-values';
+
+	let {
+		cluster,
+		namespace,
+		group,
+		version,
+		kind,
+		resource,
+		validate,
+		object,
+		onOpenChangeComplete
+	}: {
+		cluster: string;
+		namespace: string;
+		group: string;
+		version: string;
+		kind: string;
+		resource: string;
+		validate: ValidateFunction;
+		object: HelmToolkitFluxcdIoV2HelmRelease;
+		onOpenChangeComplete?: () => void;
+	} = $props();
+
+	const transport: Transport = getContext('transport');
+	const resourceClient = createClient(ResourceService, transport);
+	const runtimeClient = createClient(RuntimeService, transport);
+
+	const name = $derived(object?.metadata?.name ?? '');
+	const chartName = $derived(object?.spec?.chart?.spec?.chart ?? '');
+	const currentVersion = $derived(object?.spec?.chart?.spec?.version ?? '');
+	const sourceRef = $derived(object?.spec?.chart?.spec?.sourceRef);
+
+	let helmRepository: SourceToolkitFluxcdIoV1HelmRepository | undefined;
+	let fromHarbor = false;
+	let harborDigestByVersion: Record<string, string> = {};
+
+	let open = $state(false);
+	let isSubmitting = $state(false);
+	let currentStep = $state('1');
+	let targetVersion = $state('');
+	let mergedText = $state('');
+	let sideBySide = $state(true);
+	let hideUnchanged = $state(false);
+	let formValues = $state<FormValue>({});
+	let versions = $state<string[]>([]);
+	let isLoadingVersions = $state(false);
+	let versionsError = $state('');
+	let documentsPromise = $state<Promise<{ defaultsText: string }> | undefined>(undefined);
+
+	async function fetchVersions(): Promise<string[]> {
+		const response = await resourceClient.get({
+			cluster,
+			namespace: sourceRef?.namespace ?? namespace,
+			name: sourceRef?.name ?? '',
+			group: 'source.toolkit.fluxcd.io',
+			version: 'v1',
+			resource: 'helmrepositories'
+		});
+		helmRepository = response.object as unknown as SourceToolkitFluxcdIoV1HelmRepository;
+
+		fromHarbor =
+			lodash.get(helmRepository, ['metadata', 'labels', 'tenant.otterscale.io/from-harbor']) ===
+			'true';
+
+		let fetchedVersions: string[] = [];
+		if (fromHarbor) {
+			const harborHost = parseHarborHost(helmRepository);
+			const projectPath = encodeHarborURIComponent(parseHarborProjectName(helmRepository));
+			const repositoryPath = encodeHarborURIComponent(chartName);
+			const artifactsUrl = `/api/v2.0/projects/${projectPath}/repositories/${repositoryPath}/artifacts?with_label=true`;
+
+			const artifactsResponse = await fetch('/bff/helm/repository/harbor', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json'
+				},
+				body: JSON.stringify({
+					harborHost,
+					apiPath: artifactsUrl
+				})
+			});
+			if (!artifactsResponse.ok) {
+				throw new Error(`Failed to list versions from Harbor: ${artifactsResponse.statusText}`);
+			}
+			const artifacts: ArtifactChartType[] = await artifactsResponse.json();
+			const taggedArtifacts = artifacts.filter((artifact) => artifact.tags);
+			harborDigestByVersion = Object.fromEntries(
+				taggedArtifacts.map((artifact) => [
+					lodash.get(artifact.extra_attrs, 'version') as unknown as string,
+					artifact.digest
+				])
+			);
+			fetchedVersions = taggedArtifacts
+				.map((artifact) => lodash.get(artifact.extra_attrs, 'version') as unknown as string)
+				.filter(Boolean);
+		} else {
+			const indexResponse = await fetch('/bff/helm/repository/index', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json'
+				},
+				body: JSON.stringify({
+					repositoryUrl: helmRepository.spec?.url ?? ''
+				})
+			});
+			if (!indexResponse.ok) {
+				throw new Error(`Failed to fetch repository index: ${indexResponse.statusText}`);
+			}
+			const entries: Record<string, ChartType[]> = (await indexResponse.json()) ?? {};
+			fetchedVersions = (entries[chartName] ?? []).map((chart) => chart.version).filter(Boolean);
+		}
+
+		if (fetchedVersions.length === 0) {
+			throw new Error(`No versions found for chart ${chartName}.`);
+		}
+		return fetchedVersions;
+	}
+
+	async function loadVersions() {
+		isLoadingVersions = true;
+		versionsError = '';
+		try {
+			versions = await fetchVersions();
+			formValues = { version: versions[0] };
+		} catch (error) {
+			versionsError = error instanceof Error ? error.message : String(error);
+		} finally {
+			isLoadingVersions = false;
+		}
+	}
+
+	// Harbor registries may be plain HTTP (spec.insecure); showChart always dials
+	// OCI over HTTPS, so fetch values.yaml through the Harbor additions API instead.
+	async function fetchHarborValuesText(digest: string): Promise<string> {
+		if (!helmRepository) {
+			throw new Error('HelmRepository is not loaded.');
+		}
+		const harborHost = parseHarborHost(helmRepository);
+		const projectPath = encodeHarborURIComponent(parseHarborProjectName(helmRepository));
+		const repositoryPath = encodeHarborURIComponent(chartName);
+		const referencePath = encodeHarborURIComponent(digest);
+		const additionPath = encodeHarborURIComponent('values.yaml');
+		const additionUrl = `/api/v2.0/projects/${projectPath}/repositories/${repositoryPath}/artifacts/${referencePath}/additions/${additionPath}`;
+
+		const response = await fetch('/bff/helm/repository/harbor', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json'
+			},
+			body: JSON.stringify({
+				harborHost,
+				apiPath: additionUrl
+			})
+		});
+		if (!response.ok) {
+			throw new Error(`Failed to fetch chart values from Harbor: ${response.statusText}`);
+		}
+
+		const contentType = response.headers.get('content-type') ?? '';
+		if (contentType.includes('application/json')) {
+			const data = await response.json();
+			return typeof data === 'string' ? data : stringify(data);
+		}
+		return response.text();
+	}
+
+	async function getUpgradeDocuments(): Promise<{ defaultsText: string }> {
+		let defaultsText: string;
+		if (fromHarbor) {
+			const digest = harborDigestByVersion[targetVersion];
+			if (!digest) {
+				throw new Error(`No artifact digest found for version ${targetVersion}.`);
+			}
+			defaultsText = await fetchHarborValuesText(digest);
+		} else {
+			const response = await runtimeClient.showChart({
+				repoUrl: helmRepository?.spec?.url ?? '',
+				chartName,
+				version: targetVersion
+			});
+			defaultsText = new TextDecoder().decode(response.values);
+		}
+		const delta = (lodash.get(object, ['spec', 'values']) ?? {}) as Record<string, unknown>;
+		mergedText = applyDeltaToYamlText(defaultsText, delta);
+		return { defaultsText };
+	}
+
+	function handleUpgrade(defaultsText: string) {
+		if (isSubmitting || !validate) return;
+		isSubmitting = true;
+
+		let parsedMerged: unknown;
+		try {
+			parsedMerged = parse(mergedText) ?? {};
+		} catch (error) {
+			console.error('Failed to parse values YAML:', error);
+			toast.error('Invalid values YAML. Please check the syntax.');
+			isSubmitting = false;
+			return;
+		}
+		const valuesDelta = computeValuesDelta(parse(defaultsText), parsedMerged);
+
+		toast.promise(
+			async () => {
+				const response = await resourceClient.get({
+					cluster,
+					namespace,
+					name,
+					group,
+					version,
+					resource
+				});
+
+				const helmRelease: HelmToolkitFluxcdIoV2HelmRelease = lodash.cloneDeep(
+					response.object ?? {}
+				);
+				lodash.set(helmRelease, ['spec', 'chart', 'spec', 'version'], targetVersion);
+				lodash.set(helmRelease, ['spec', 'values'], valuesDelta);
+				const manifest = stringify(helmRelease, { schema: 'yaml-1.1' });
+
+				let isValid: boolean | undefined = undefined;
+				try {
+					isValid = validate(load(manifest, { schema: JSON_SCHEMA }));
+				} catch (error) {
+					console.error(`Failed to parse HelmRelease manifest for ${name}:`, error);
+					throw new Error(`Invalid YAML for ${name}.`);
+				}
+				if (!isValid) {
+					console.error(`Validation errors for ${name}:`, validate.errors);
+					throw new Error(`Validation failed for ${name}.`);
+				}
+
+				await resourceClient.update({
+					cluster,
+					namespace,
+					group,
+					version,
+					resource,
+					name,
+					manifest: new TextEncoder().encode(manifest),
+					fieldManager: 'otterscale-web-ui'
+				});
+			},
+			{
+				loading: `Upgrading ${kind} ${name} to ${targetVersion}…`,
+				success: () => `Successfully upgraded ${kind} ${name} to ${targetVersion}`,
+				error: (error) => {
+					console.error(`Failed to upgrade ${kind} ${name}:`, error);
+					return `Failed to upgrade ${kind} ${name}: ${(error as ConnectError).message}`;
+				},
+				finally() {
+					isSubmitting = false;
+					open = false;
+				}
+			}
+		);
+	}
+
+	function initiate() {
+		currentStep = '1';
+		targetVersion = '';
+		mergedText = '';
+		formValues = {};
+		versions = [];
+		versionsError = '';
+		documentsPromise = undefined;
+		fromHarbor = false;
+		harborDigestByVersion = {};
+		isSubmitting = false;
+	}
+
+	const contentClass = $derived(
+		currentStep === '2'
+			? 'flex max-h-[95vh] min-h-[95vh] max-w-[95vw] min-w-[95vw] flex-col gap-4 p-6'
+			: 'max-h-[95vh] overflow-auto'
+	);
+</script>
+
+<Dialog.Root
+	bind:open
+	onOpenChange={(isOpen) => {
+		if (isOpen) {
+			loadVersions();
+		}
+	}}
+	onOpenChangeComplete={(isOpen) => {
+		onOpenChangeComplete?.();
+
+		if (isOpen) return;
+
+		initiate();
+	}}
+>
+	<Dialog.Trigger>
+		{#snippet child({ props })}
+			<Item.Root {...props} class="w-full p-0 text-xs" size="sm">
+				<Item.Media>
+					<ArrowUpCircleIcon />
+				</Item.Media>
+				<Item.Content>
+					<Item.Title>Upgrade</Item.Title>
+				</Item.Content>
+			</Item.Root>
+		{/snippet}
+	</Dialog.Trigger>
+
+	<Dialog.Content class={contentClass} onInteractOutside={(e) => e.preventDefault()}>
+		<Item.Root class="p-0">
+			<Item.Content class="text-left">
+				<Item.Title class="text-xl font-bold">Upgrade — {name}</Item.Title>
+				<Item.Description>
+					Chart <strong>{chartName}</strong> · current version <strong>{currentVersion}</strong>
+				</Item.Description>
+			</Item.Content>
+		</Item.Root>
+
+		{#if currentStep === '1'}
+			{#if versionsError}
+				<Empty.Root class="rounded-lg bg-muted">
+					<Empty.Header>
+						<Empty.Media variant="icon">
+							<FileIcon size={32} class="opacity-60" aria-hidden="true" />
+						</Empty.Media>
+						<Empty.Title>Failed to load chart versions</Empty.Title>
+						<Empty.Description>
+							{versionsError}
+						</Empty.Description>
+					</Empty.Header>
+				</Empty.Root>
+			{:else}
+				<!-- One persistent form for the loading and loaded states: while the
+				     version list loads, the combobox shows the current version and the
+				     submit stays disabled — no remount, no flash. -->
+				<Form
+					schema={{
+						type: 'object',
+						required: ['version'],
+						properties: {
+							version: {
+								title: 'Version',
+								type: 'string',
+								enum: versions.length > 0 ? versions : [currentVersion]
+							}
+						}
+					} as Schema}
+					uiSchema={{
+						'ui:options': {
+							layouts: {
+								'object-properties': {
+									class: 'gap-3'
+								}
+							},
+							translations: {
+								submit: 'Next'
+							}
+						},
+						version: {
+							'ui:options': {
+								help: 'Select a Version'
+							},
+							'ui:components': {
+								stringField: 'enumField',
+								selectWidget: 'comboboxWidget'
+							}
+						}
+					} as UiSchemaRoot}
+					initialValue={{ version: currentVersion } as FormValue}
+					bind:values={formValues}
+					handleSubmit={{
+						posthook: (form: FormState<FormValue>) => {
+							if (isLoadingVersions || versions.length === 0) return;
+
+							const formValue = getValueSnapshot(form);
+							const selected = formValue
+								? (lodash.get(formValue, 'version') as string)
+								: versions[0];
+							if (!selected) return;
+
+							// Keep the user's in-editor edits when they step back and
+							// forward without changing the target version.
+							if (selected !== targetVersion || !documentsPromise) {
+								targetVersion = selected;
+								documentsPromise = getUpgradeDocuments();
+							}
+							currentStep = '2';
+						}
+					}}
+					class="**:data-[slot=dynamic-form-mode-controller]:hidden"
+				>
+					{#snippet actions()}
+						<div class="*:w-full">
+							{#if isLoadingVersions}
+								<Button disabled>Next</Button>
+							{:else}
+								<SubmitButton />
+							{/if}
+						</div>
+					{/snippet}
+				</Form>
+			{/if}
+		{:else if documentsPromise}
+			{#await documentsPromise}
+				<div class="min-h-0 flex-1 rounded-md border bg-muted">
+					<Empty.Root class="h-full">
+						<Empty.Header>
+							<Empty.Media variant="icon">
+								<Spinner />
+							</Empty.Media>
+							<Empty.Title>Loading chart values</Empty.Title>
+						</Empty.Header>
+					</Empty.Root>
+				</div>
+			{:then documents}
+				<div class="flex min-h-0 flex-1 flex-col">
+					<div
+						class="flex h-10 shrink-0 items-center justify-between rounded-t-md border border-b-0 bg-background/50 px-3 text-xs"
+					>
+						<span class="text-muted-foreground">
+							Chart defaults ({targetVersion}) — highlighted lines are your overrides
+						</span>
+						<div class="flex items-center gap-1">
+							<span class="text-muted-foreground">Your values — editable</span>
+							<Tooltip.Root ignoreNonKeyboardFocus>
+								<Tooltip.Trigger>
+									{#snippet child({ props })}
+										<Toggle
+											{...props}
+											class="size-8 p-0"
+											bind:pressed={hideUnchanged}
+											aria-label="Show changed regions only"
+										>
+											<FoldVerticalIcon />
+										</Toggle>
+									{/snippet}
+								</Tooltip.Trigger>
+								<Tooltip.Content>Show changed regions only</Tooltip.Content>
+							</Tooltip.Root>
+							<Tooltip.Root ignoreNonKeyboardFocus>
+								<Tooltip.Trigger>
+									{#snippet child({ props })}
+										<Toggle
+											{...props}
+											class="size-8 p-0"
+											bind:pressed={sideBySide}
+											aria-label="Toggle side-by-side diff"
+										>
+											<Columns2Icon />
+										</Toggle>
+									{/snippet}
+								</Tooltip.Trigger>
+								<Tooltip.Content>Side-by-side diff</Tooltip.Content>
+							</Tooltip.Root>
+						</div>
+					</div>
+					<!-- Monaco needs a definite height; percentage heights do not resolve
+					     through the flex chain, so pin it with an absolute layer. -->
+					<div class="relative min-h-0 flex-1 overflow-hidden rounded-b-md border">
+						<div class="absolute inset-0">
+							<MonacoDiff
+								original={documents.defaultsText}
+								bind:modified={mergedText}
+								renderSideBySide={sideBySide}
+								{hideUnchanged}
+								theme={themeMode.current === 'dark' ? 'vs-dark' : 'vs'}
+								options={{ padding: { top: 16, bottom: 8 } }}
+							/>
+						</div>
+					</div>
+				</div>
+				<div class="flex w-full shrink-0 items-center justify-between gap-3">
+					<Button
+						onclick={() => {
+							currentStep = '1';
+						}}
+					>
+						Previous
+					</Button>
+					<Button disabled={isSubmitting} onclick={() => handleUpgrade(documents.defaultsText)}>
+						{#if isSubmitting}
+							Upgrading…
+						{:else}
+							Upgrade
+						{/if}
+					</Button>
+				</div>
+			{:catch error}
+				<Empty.Root class="rounded-lg bg-muted">
+					<Empty.Header>
+						<Empty.Media variant="icon">
+							<FileIcon size={32} class="opacity-60" aria-hidden="true" />
+						</Empty.Media>
+						<Empty.Title>Failed to load chart values</Empty.Title>
+						<Empty.Description>
+							{error.message}
+						</Empty.Description>
+					</Empty.Header>
+				</Empty.Root>
+				<div class="flex w-full items-center justify-start">
+					<Button
+						onclick={() => {
+							currentStep = '1';
+						}}
+					>
+						Previous
+					</Button>
+				</div>
+			{/await}
+		{/if}
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/lib/utils/helm-values.spec.ts
+++ b/src/lib/utils/helm-values.spec.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
+
+import { applyDeltaToYamlText, computeValuesDelta } from './helm-values';
+
+describe('computeValuesDelta', () => {
+	const defaults = {
+		replicas: 1,
+		image: { repository: 'nginx', tag: 'latest' },
+		resources: { limits: { cpu: '100m', memory: '128Mi' } },
+		tolerations: [{ key: 'a' }],
+		auth: { existingSecret: '' }
+	};
+
+	it('returns empty object when nothing changed', () => {
+		expect(computeValuesDelta(defaults, structuredClone(defaults))).toEqual({});
+	});
+
+	it('keeps only changed keys, recursing into objects', () => {
+		const edited = structuredClone(defaults);
+		edited.replicas = 3;
+		edited.resources.limits.cpu = '200m';
+		expect(computeValuesDelta(defaults, edited)).toEqual({
+			replicas: 3,
+			resources: { limits: { cpu: '200m' } }
+		});
+	});
+
+	it('treats arrays as whole values', () => {
+		const edited = structuredClone(defaults);
+		edited.tolerations = [{ key: 'a' }, { key: 'b' }];
+		expect(computeValuesDelta(defaults, edited)).toEqual({
+			tolerations: [{ key: 'a' }, { key: 'b' }]
+		});
+	});
+
+	it('keeps explicit null overrides (helm "remove default" semantics)', () => {
+		const edited = structuredClone(defaults) as Record<string, unknown>;
+		edited.auth = null;
+		expect(computeValuesDelta(defaults, edited)).toEqual({ auth: null });
+	});
+
+	it('records new keys absent from defaults', () => {
+		const edited = { ...structuredClone(defaults), extraEnv: { FOO: 'bar' } };
+		expect(computeValuesDelta(defaults, edited)).toEqual({ extraEnv: { FOO: 'bar' } });
+	});
+
+	it('compares Date values by time (js-yaml parses YAML timestamps into Date)', () => {
+		const withDate = { ...structuredClone(defaults), notBefore: new Date('2026-01-01') };
+		const sameDate = { ...structuredClone(defaults), notBefore: new Date('2026-01-01') };
+		const changedDate = { ...structuredClone(defaults), notBefore: new Date('2026-06-01') };
+		expect(computeValuesDelta(withDate, sameDate)).toEqual({});
+		expect(computeValuesDelta(withDate, changedDate)).toEqual({
+			notBefore: new Date('2026-06-01')
+		});
+	});
+
+	it('is idempotent when the input is already a delta', () => {
+		const delta = { replicas: 3, resources: { limits: { cpu: '200m' } } };
+		expect(computeValuesDelta(defaults, delta)).toEqual(delta);
+	});
+});
+
+describe('applyDeltaToYamlText', () => {
+	const yamlText = [
+		'# Number of replicas',
+		'replicas: 1',
+		'image:',
+		'  # Container image repository',
+		'  repository: nginx',
+		'  tag: latest',
+		'tolerations: []',
+		''
+	].join('\n');
+
+	it('applies scalar overrides while preserving comments', () => {
+		const merged = applyDeltaToYamlText(yamlText, { replicas: 3 });
+		expect(merged).toContain('# Number of replicas');
+		expect(merged).toContain('replicas: 3');
+		expect(merged).toContain('# Container image repository');
+	});
+
+	it('descends into mappings and adds new keys', () => {
+		const merged = applyDeltaToYamlText(yamlText, {
+			image: { tag: '1.25' },
+			extraEnv: { FOO: 'bar' }
+		});
+		expect(parse(merged)).toEqual({
+			replicas: 1,
+			image: { repository: 'nginx', tag: '1.25' },
+			tolerations: [],
+			extraEnv: { FOO: 'bar' }
+		});
+		expect(merged).toContain('# Container image repository');
+	});
+
+	it('replaces arrays wholesale', () => {
+		const merged = applyDeltaToYamlText(yamlText, { tolerations: [{ key: 'a' }] });
+		expect(parse(merged).tolerations).toEqual([{ key: 'a' }]);
+	});
+
+	it('round-trips: delta of merged text against defaults equals the delta', () => {
+		const delta = { replicas: 3, image: { tag: '1.25' }, extraEnv: { FOO: 'bar' } };
+		const merged = applyDeltaToYamlText(yamlText, delta);
+		expect(computeValuesDelta(parse(yamlText), parse(merged))).toEqual(delta);
+	});
+});

--- a/src/lib/utils/helm-values.ts
+++ b/src/lib/utils/helm-values.ts
@@ -1,0 +1,79 @@
+import { isMap, parseDocument } from 'yaml';
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return (
+		typeof value === 'object' && value !== null && !Array.isArray(value) && !(value instanceof Date)
+	);
+}
+
+function isEqualValue(a: unknown, b: unknown): boolean {
+	if (Object.is(a, b)) return true;
+	if (typeof a !== 'object' || typeof b !== 'object' || a === null || b === null) return false;
+	// js-yaml parses YAML timestamps into Date objects, which have no enumerable keys.
+	if (a instanceof Date || b instanceof Date) {
+		return a instanceof Date && b instanceof Date && a.getTime() === b.getTime();
+	}
+	if (Array.isArray(a) !== Array.isArray(b)) return false;
+	const aKeys = Object.keys(a);
+	const bKeys = Object.keys(b);
+	if (aKeys.length !== bKeys.length) return false;
+	return aKeys.every((key) =>
+		isEqualValue((a as Record<string, unknown>)[key], (b as Record<string, unknown>)[key])
+	);
+}
+
+/**
+ * Computes the minimal override set between a chart's default values and the
+ * user-edited values, so HelmRelease `spec.values` stores only what differs
+ * from the chart defaults (Helm fills the rest at render time).
+ *
+ * Objects are compared recursively; arrays and scalars are compared as whole
+ * values. Explicit `null` overrides are kept — in Helm they mean "remove the
+ * default". Keys the user deleted are not recorded; Helm falls back to the
+ * chart default for missing keys, which matches the previous behavior.
+ */
+function computeValuesDelta(defaults: unknown, userValues: unknown): Record<string, unknown> {
+	if (!isPlainObject(userValues)) return {};
+	const defaultsObject = isPlainObject(defaults) ? defaults : {};
+
+	const delta: Record<string, unknown> = {};
+	for (const [key, userValue] of Object.entries(userValues)) {
+		const defaultValue = defaultsObject[key];
+		if (isPlainObject(userValue) && isPlainObject(defaultValue)) {
+			const nested = computeValuesDelta(defaultValue, userValue);
+			if (Object.keys(nested).length > 0) {
+				delta[key] = nested;
+			}
+		} else if (!isEqualValue(userValue, defaultValue)) {
+			delta[key] = userValue;
+		}
+	}
+	return delta;
+}
+
+/**
+ * Applies a values override set onto a chart's default values.yaml text,
+ * preserving the original comments and formatting. Overrides descend into
+ * existing mappings key by key; anything else (scalars, arrays, new keys)
+ * replaces the node at that path.
+ */
+function applyDeltaToYamlText(yamlText: string, delta: Record<string, unknown>): string {
+	const document = parseDocument(yamlText);
+
+	function apply(path: string[], value: unknown) {
+		if (isPlainObject(value) && isMap(document.getIn(path))) {
+			for (const [key, child] of Object.entries(value)) {
+				apply([...path, key], child);
+			}
+		} else {
+			document.setIn(path, value);
+		}
+	}
+
+	for (const [key, child] of Object.entries(delta)) {
+		apply([key], child);
+	}
+	return document.toString();
+}
+
+export { applyDeltaToYamlText, computeValuesDelta };


### PR DESCRIPTION
- store only the delta vs chart default values in HelmRelease spec.values on install (index & harbor), so new chart defaults take effect on upgrade
- add computeValuesDelta / applyDeltaToYamlText utilities with unit tests; merge preserves values.yaml comments via the yaml Document API
- add MonacoDiff wrapper component (editable right pane, side-by-side and changed-regions-only toggles, definite-height layout inside flex dialogs)
- add helm-release Upgrade action: pick a target version (harbor or index repository), review new chart defaults vs merged values in a diff editor, then submit the re-diffed delta together with the new chart version
- fetch harbor chart values through the BFF additions API so plain-HTTP (insecure) registries work