### PR TITLE
fix(helm-release): stabilize upgrade diff and Harbor version list

### DIFF
--- a/src/lib/components/kind-viewer/kind-viewer-actions/helm-release/upgrade.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/helm-release/upgrade.svelte
@@ -35,7 +35,11 @@
 	import { Spinner } from '$lib/components/ui/spinner';
 	import { Toggle } from '$lib/components/ui/toggle';
 	import * as Tooltip from '$lib/components/ui/tooltip';
-	import { applyDeltaToYamlText, computeValuesDelta } from '$lib/utils/helm-values';
+	import {
+		applyDeltaToYamlText,
+		computeValuesDelta,
+		normalizeYamlText
+	} from '$lib/utils/helm-values';
 
 	let {
 		cluster,
@@ -79,10 +83,7 @@
 	let mergedText = $state('');
 	let sideBySide = $state(true);
 	let hideUnchanged = $state(false);
-	let formValues = $state<FormValue>({});
-	let versions = $state<string[]>([]);
-	let isLoadingVersions = $state(false);
-	let versionsError = $state('');
+	let versionsPromise = $state<Promise<string[]> | undefined>(undefined);
 	let documentsPromise = $state<Promise<{ defaultsText: string }> | undefined>(undefined);
 
 	async function fetchVersions(): Promise<string[]> {
@@ -121,16 +122,18 @@
 				throw new Error(`Failed to list versions from Harbor: ${artifactsResponse.statusText}`);
 			}
 			const artifacts: ArtifactChartType[] = await artifactsResponse.json();
-			const taggedArtifacts = artifacts.filter((artifact) => artifact.tags);
+			const taggedArtifacts = artifacts.filter((artifact) => artifact.tags?.length);
+			// Helm OCI convention: the tag name is the chart version. Fall back to it
+			// when Harbor did not parse chart metadata into extra_attrs.
+			const versionOf = (artifact: ArtifactChartType) =>
+				(lodash.get(artifact.extra_attrs, 'version') as unknown as string) ||
+				artifact.tags[0]?.name;
 			harborDigestByVersion = Object.fromEntries(
-				taggedArtifacts.map((artifact) => [
-					lodash.get(artifact.extra_attrs, 'version') as unknown as string,
-					artifact.digest
-				])
+				taggedArtifacts
+					.filter((artifact) => Boolean(versionOf(artifact)))
+					.map((artifact) => [versionOf(artifact), artifact.digest])
 			);
-			fetchedVersions = taggedArtifacts
-				.map((artifact) => lodash.get(artifact.extra_attrs, 'version') as unknown as string)
-				.filter(Boolean);
+			fetchedVersions = taggedArtifacts.map(versionOf).filter(Boolean);
 		} else {
 			const indexResponse = await fetch('/bff/helm/repository/index', {
 				method: 'POST',
@@ -151,20 +154,25 @@
 		if (fetchedVersions.length === 0) {
 			throw new Error(`No versions found for chart ${chartName}.`);
 		}
-		return fetchedVersions;
+		return fetchedVersions.sort(compareVersionsDescending);
 	}
 
-	async function loadVersions() {
-		isLoadingVersions = true;
-		versionsError = '';
-		try {
-			versions = await fetchVersions();
-			formValues = { version: versions[0] };
-		} catch (error) {
-			versionsError = error instanceof Error ? error.message : String(error);
-		} finally {
-			isLoadingVersions = false;
+	// Harbor lists artifacts by push time, not by version; a re-pushed old chart
+	// would otherwise show up first and become the default selection.
+	function compareVersionsDescending(a: string, b: string): number {
+		const aParts = a.replace(/^v/, '').split(/[.+-]/);
+		const bParts = b.replace(/^v/, '').split(/[.+-]/);
+		const length = Math.max(aParts.length, bParts.length);
+		for (let i = 0; i < length; i++) {
+			const aPart = aParts[i] ?? '';
+			const bPart = bParts[i] ?? '';
+			if (aPart === bPart) continue;
+			const aNumber = Number(aPart);
+			const bNumber = Number(bPart);
+			if (!Number.isNaN(aNumber) && !Number.isNaN(bNumber)) return bNumber - aNumber;
+			return bPart.localeCompare(aPart);
 		}
+		return 0;
 	}
 
 	// Harbor registries may be plain HTTP (spec.insecure); showChart always dials
@@ -218,9 +226,26 @@
 			});
 			defaultsText = new TextDecoder().decode(response.values);
 		}
+		// Both diff panes have to come out of the same YAML printer, otherwise
+		// round-trip formatting alone reads as an override.
+		const normalizedDefaults = normalizeYamlText(defaultsText);
 		const delta = (lodash.get(object, ['spec', 'values']) ?? {}) as Record<string, unknown>;
-		mergedText = applyDeltaToYamlText(defaultsText, delta);
-		return { defaultsText };
+		mergedText = applyDeltaToYamlText(normalizedDefaults, delta);
+		return { defaultsText: normalizedDefaults };
+	}
+
+	function selectVersion(form: FormState<FormValue>, fallback: string) {
+		const formValue = getValueSnapshot(form);
+		const selected = (formValue ? lodash.get(formValue, 'version') : fallback) as string;
+		if (!selected) return;
+
+		// Keep the user's in-editor edits when they step back and forward
+		// without changing the target version.
+		if (selected !== targetVersion || !documentsPromise) {
+			targetVersion = selected;
+			documentsPromise = getUpgradeDocuments();
+		}
+		currentStep = '2';
 	}
 
 	function handleUpgrade(defaultsText: string) {
@@ -298,9 +323,7 @@
 		currentStep = '1';
 		targetVersion = '';
 		mergedText = '';
-		formValues = {};
-		versions = [];
-		versionsError = '';
+		versionsPromise = undefined;
 		documentsPromise = undefined;
 		fromHarbor = false;
 		harborDigestByVersion = {};
@@ -314,11 +337,76 @@
 	);
 </script>
 
+{#snippet loadFailure(title: string, description: string)}
+	<Empty.Root class="rounded-lg bg-muted">
+		<Empty.Header>
+			<Empty.Media variant="icon">
+				<FileIcon size={32} class="opacity-60" aria-hidden="true" />
+			</Empty.Media>
+			<Empty.Title>{title}</Empty.Title>
+			<Empty.Description>{description}</Empty.Description>
+		</Empty.Header>
+	</Empty.Root>
+{/snippet}
+
+<!-- createForm captures schema, initialValue and disabled once at mount
+     (form.svelte), so the pending and resolved states each need their own
+     instance — same markup, so render both from here. -->
+{#snippet versionForm(options: string[], isLoading: boolean)}
+	<Form
+		schema={{
+			type: 'object',
+			required: ['version'],
+			properties: {
+				version: {
+					title: 'Version',
+					type: 'string',
+					enum: options
+				}
+			}
+		} as Schema}
+		uiSchema={{
+			'ui:options': {
+				layouts: {
+					'object-properties': {
+						class: 'gap-3'
+					}
+				},
+				translations: {
+					submit: 'Next'
+				}
+			},
+			version: {
+				'ui:options': {
+					help: 'Select a Version'
+				},
+				'ui:components': {
+					stringField: 'enumField'
+				}
+			}
+		} as UiSchemaRoot}
+		initialValue={{ version: targetVersion || options[0] } as FormValue}
+		disabled={isLoading}
+		handleSubmit={{ posthook: (form) => selectVersion(form, options[0]) }}
+		class="**:data-[slot=dynamic-form-mode-controller]:hidden"
+	>
+		{#snippet actions()}
+			<div class="*:w-full">
+				{#if isLoading}
+					<Button disabled>Next</Button>
+				{:else}
+					<SubmitButton />
+				{/if}
+			</div>
+		{/snippet}
+	</Form>
+{/snippet}
+
 <Dialog.Root
 	bind:open
 	onOpenChange={(isOpen) => {
 		if (isOpen) {
-			loadVersions();
+			versionsPromise = fetchVersions();
 		}
 	}}
 	onOpenChangeComplete={(isOpen) => {
@@ -353,88 +441,14 @@
 		</Item.Root>
 
 		{#if currentStep === '1'}
-			{#if versionsError}
-				<Empty.Root class="rounded-lg bg-muted">
-					<Empty.Header>
-						<Empty.Media variant="icon">
-							<FileIcon size={32} class="opacity-60" aria-hidden="true" />
-						</Empty.Media>
-						<Empty.Title>Failed to load chart versions</Empty.Title>
-						<Empty.Description>
-							{versionsError}
-						</Empty.Description>
-					</Empty.Header>
-				</Empty.Root>
-			{:else}
-				<!-- One persistent form for the loading and loaded states: while the
-				     version list loads, the combobox shows the current version and the
-				     submit stays disabled — no remount, no flash. -->
-				<Form
-					schema={{
-						type: 'object',
-						required: ['version'],
-						properties: {
-							version: {
-								title: 'Version',
-								type: 'string',
-								enum: versions.length > 0 ? versions : [currentVersion]
-							}
-						}
-					} as Schema}
-					uiSchema={{
-						'ui:options': {
-							layouts: {
-								'object-properties': {
-									class: 'gap-3'
-								}
-							},
-							translations: {
-								submit: 'Next'
-							}
-						},
-						version: {
-							'ui:options': {
-								help: 'Select a Version'
-							},
-							'ui:components': {
-								stringField: 'enumField',
-								selectWidget: 'comboboxWidget'
-							}
-						}
-					} as UiSchemaRoot}
-					initialValue={{ version: currentVersion } as FormValue}
-					bind:values={formValues}
-					handleSubmit={{
-						posthook: (form: FormState<FormValue>) => {
-							if (isLoadingVersions || versions.length === 0) return;
-
-							const formValue = getValueSnapshot(form);
-							const selected = formValue
-								? (lodash.get(formValue, 'version') as string)
-								: versions[0];
-							if (!selected) return;
-
-							// Keep the user's in-editor edits when they step back and
-							// forward without changing the target version.
-							if (selected !== targetVersion || !documentsPromise) {
-								targetVersion = selected;
-								documentsPromise = getUpgradeDocuments();
-							}
-							currentStep = '2';
-						}
-					}}
-					class="**:data-[slot=dynamic-form-mode-controller]:hidden"
-				>
-					{#snippet actions()}
-						<div class="*:w-full">
-							{#if isLoadingVersions}
-								<Button disabled>Next</Button>
-							{:else}
-								<SubmitButton />
-							{/if}
-						</div>
-					{/snippet}
-				</Form>
+			{#if versionsPromise}
+				{#await versionsPromise}
+					{@render versionForm(['Loading…'], true)}
+				{:then versions}
+					{@render versionForm(versions, false)}
+				{:catch error}
+					{@render loadFailure('Failed to load chart versions', error.message)}
+				{/await}
 			{/if}
 		{:else if documentsPromise}
 			{#await documentsPromise}
@@ -522,17 +536,7 @@
 					</Button>
 				</div>
 			{:catch error}
-				<Empty.Root class="rounded-lg bg-muted">
-					<Empty.Header>
-						<Empty.Media variant="icon">
-							<FileIcon size={32} class="opacity-60" aria-hidden="true" />
-						</Empty.Media>
-						<Empty.Title>Failed to load chart values</Empty.Title>
-						<Empty.Description>
-							{error.message}
-						</Empty.Description>
-					</Empty.Header>
-				</Empty.Root>
+				{@render loadFailure('Failed to load chart values', error.message)}
 				<div class="flex w-full items-center justify-start">
 					<Button
 						onclick={() => {

--- a/src/lib/components/kind-viewer/kind-viewer-actions/helm-release/upgrade.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/helm-release/upgrade.svelte
@@ -16,6 +16,7 @@
 	import { JSON_SCHEMA, load } from 'js-yaml';
 	import lodash from 'lodash';
 	import { mode as themeMode } from 'mode-watcher';
+	import semver from 'semver';
 	import { getContext } from 'svelte';
 	import { toast } from 'svelte-sonner';
 	import { parse, stringify } from 'yaml';
@@ -154,25 +155,14 @@
 		if (fetchedVersions.length === 0) {
 			throw new Error(`No versions found for chart ${chartName}.`);
 		}
-		return fetchedVersions.sort(compareVersionsDescending);
-	}
-
-	// Harbor lists artifacts by push time, not by version; a re-pushed old chart
-	// would otherwise show up first and become the default selection.
-	function compareVersionsDescending(a: string, b: string): number {
-		const aParts = a.replace(/^v/, '').split(/[.+-]/);
-		const bParts = b.replace(/^v/, '').split(/[.+-]/);
-		const length = Math.max(aParts.length, bParts.length);
-		for (let i = 0; i < length; i++) {
-			const aPart = aParts[i] ?? '';
-			const bPart = bParts[i] ?? '';
-			if (aPart === bPart) continue;
-			const aNumber = Number(aPart);
-			const bNumber = Number(bPart);
-			if (!Number.isNaN(aNumber) && !Number.isNaN(bNumber)) return bNumber - aNumber;
-			return bPart.localeCompare(aPart);
-		}
-		return 0;
+		// Harbor lists artifacts by push time, not by version; a re-pushed old chart
+		// would otherwise show up first and become the default selection. Helm
+		// requires SemVer 2 chart versions, but a raw OCI tag may not be one —
+		// those sort last instead of making rcompare throw.
+		return fetchedVersions.sort((a, b) => {
+			if (semver.valid(a) && semver.valid(b)) return semver.rcompare(a, b);
+			return semver.valid(a) ? -1 : semver.valid(b) ? 1 : 0;
+		});
 	}
 
 	// Harbor registries may be plain HTTP (spec.insecure); showChart always dials

--- a/src/lib/utils/helm-values.spec.ts
+++ b/src/lib/utils/helm-values.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { parse } from 'yaml';
 
-import { applyDeltaToYamlText, computeValuesDelta } from './helm-values';
+import { applyDeltaToYamlText, computeValuesDelta, normalizeYamlText } from './helm-values';
 
 describe('computeValuesDelta', () => {
 	const defaults = {
@@ -103,5 +103,40 @@ describe('applyDeltaToYamlText', () => {
 		const delta = { replicas: 3, image: { tag: '1.25' }, extraEnv: { FOO: 'bar' } };
 		const merged = applyDeltaToYamlText(yamlText, delta);
 		expect(computeValuesDelta(parse(yamlText), parse(merged))).toEqual(delta);
+	});
+
+	it('does not fold long scalars onto continuation lines', () => {
+		const longUrl =
+			'http://otterscale-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090';
+		const merged = applyDeltaToYamlText(yamlText, { prometheus: { url: longUrl } });
+		expect(merged).toContain(`url: ${longUrl}\n`);
+		expect(merged).not.toContain('\\\n');
+	});
+});
+
+describe('normalizeYamlText', () => {
+	// Trailing comments padded for alignment, plus a scalar past the default
+	// 80-column fold width — both get reflowed by the printer.
+	const yamlText = [
+		'backend:',
+		'  imageTag: ""            # empty falls back to Chart.appVersion',
+		'prometheus:',
+		'  url: "http://otterscale-prometheus-kube-prometheus.monitoring.svc.cluster.local:9090"',
+		''
+	].join('\n');
+
+	it('matches the printed form of an unmodified merge, so the diff stays clean', () => {
+		expect(normalizeYamlText(yamlText)).toBe(applyDeltaToYamlText(yamlText, {}));
+	});
+
+	it('is idempotent', () => {
+		const once = normalizeYamlText(yamlText);
+		expect(normalizeYamlText(once)).toBe(once);
+	});
+
+	it('preserves values and comments', () => {
+		const normalized = normalizeYamlText(yamlText);
+		expect(parse(normalized)).toEqual(parse(yamlText));
+		expect(normalized).toContain('# empty falls back to Chart.appVersion');
 	});
 });

--- a/src/lib/utils/helm-values.ts
+++ b/src/lib/utils/helm-values.ts
@@ -1,5 +1,11 @@
 import { isMap, parseDocument } from 'yaml';
 
+// The printer reflows anything it emits: long scalars fold onto continuation
+// lines and the padding some charts use to align trailing comments collapses to
+// a single space. Disable folding, and print both sides of a diff through these
+// same options so only real value changes show up.
+const TO_STRING_OPTIONS = { lineWidth: 0 } as const;
+
 function isPlainObject(value: unknown): value is Record<string, unknown> {
 	return (
 		typeof value === 'object' && value !== null && !Array.isArray(value) && !(value instanceof Date)
@@ -73,7 +79,17 @@ function applyDeltaToYamlText(yamlText: string, delta: Record<string, unknown>):
 	for (const [key, child] of Object.entries(delta)) {
 		apply([key], child);
 	}
-	return document.toString();
+	return document.toString(TO_STRING_OPTIONS);
 }
 
-export { applyDeltaToYamlText, computeValuesDelta };
+/**
+ * Round-trips a values.yaml through the same printer `applyDeltaToYamlText`
+ * uses. Diffing raw chart defaults against printed merged values would flag
+ * comment spacing and folded long lines as changes; normalizing both sides
+ * leaves only the real overrides highlighted.
+ */
+function normalizeYamlText(yamlText: string): string {
+	return parseDocument(yamlText).toString(TO_STRING_OPTIONS);
+}
+
+export { applyDeltaToYamlText, computeValuesDelta, normalizeYamlText };


### PR DESCRIPTION
- print both diff panes through the same YAML printer with folding disabled (lineWidth: 0); long scalars and comment alignment padding were reflowed on merge only, so formatting alone showed up as an override. Adds normalizeYamlText with unit tests
- fall back to the OCI tag name when Harbor did not parse chart metadata into extra_attrs, so those artifacts are no longer dropped from the version list
- sort versions descending; Harbor lists artifacts by push time, so a re-pushed old chart became the default selection
- drive step 1 from a versionsPromise via {#await} instead of manual loading/error state, and share the version form / load-failure markup as snippets