### PR TITLE
fix(dashboard): follow HAMi metric rename so GPU panels resolve

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -376,6 +376,8 @@
 	"wait": "Wait",
 	"delay": "Delay",
 	"no_data_display": "No data to display",
+	"no_traffic_display": "No requests in this range",
+	"no_traffic_hint": "The model is running but received no traffic.",
 	"no_data_available": "No data available",
 	"no_result": "No results",
 	"ram": "RAM",

--- a/messages/zh-hant.json
+++ b/messages/zh-hant.json
@@ -376,6 +376,8 @@
 	"wait": "等待",
 	"delay": "延遲",
 	"no_data_display": "尚無資料可顯示",
+	"no_traffic_display": "此區間內沒有請求",
+	"no_traffic_hint": "模型運行中,但沒有收到流量。",
 	"no_data_available": "目前無可用資料",
 	"no_result": "無結果",
 	"ram": "記憶體",

--- a/src/lib/components/custom/top-bar-list/top-bar-list.svelte
+++ b/src/lib/components/custom/top-bar-list/top-bar-list.svelte
@@ -3,6 +3,7 @@
 	import InfoIcon from '@lucide/svelte/icons/info';
 	import LoaderCircle from '@lucide/svelte/icons/loader-circle';
 	import Maximize2Icon from '@lucide/svelte/icons/maximize-2';
+	import MoonIcon from '@lucide/svelte/icons/moon';
 
 	import * as Statistics from '$lib/components/custom/statistics/index';
 	import { Badge } from '$lib/components/ui/badge';
@@ -11,6 +12,7 @@
 	import * as Sheet from '$lib/components/ui/sheet';
 	import * as Tooltip from '$lib/components/ui/tooltip';
 	import { m } from '$lib/messages';
+	import type { ActivityState } from '$lib/prometheus';
 	import { cn } from '$lib/utils';
 
 	import type { TopBar } from './types';
@@ -22,7 +24,8 @@
 		bars,
 		isLoaded,
 		onBarClick,
-		scrollable
+		scrollable,
+		activity
 	}: {
 		title: string;
 		description: string;
@@ -30,6 +33,9 @@
 		bars: TopBar[];
 		isLoaded: boolean;
 		onBarClick?: (label: string) => void;
+		// Optional: when the caller can tell "the workload is idle" apart from "nothing is
+		// deployed", pass it so the empty state says which. Omit for the generic message.
+		activity?: ActivityState;
 		// When true, the list lives in a fixed-height scroll area with a maximize button — so
 		// cards sharing a row stay the same height regardless of how many bars each has.
 		// Leave false to let the list grow with its content.
@@ -120,9 +126,15 @@
 				<LoaderCircle class="size-12 animate-spin" />
 			</div>
 		{:else if bars.length === 0}
-			<div class="flex h-65 w-full flex-col items-center justify-center">
-				<ChartLine class="size-12 animate-pulse text-muted-foreground" />
-				<p class="text-base text-muted-foreground">{m.no_data_display()}</p>
+			<div class="flex h-65 w-full flex-col items-center justify-center gap-1">
+				{#if activity === 'idle'}
+					<MoonIcon class="size-12 text-muted-foreground" />
+					<p class="text-base text-muted-foreground">{m.no_traffic_display()}</p>
+					<p class="text-xs text-muted-foreground">{m.no_traffic_hint()}</p>
+				{:else}
+					<ChartLine class="size-12 animate-pulse text-muted-foreground" />
+					<p class="text-base text-muted-foreground">{m.no_data_display()}</p>
+				{/if}
 			</div>
 		{:else if scrollable}
 			<ScrollArea class="h-65 w-full">

--- a/src/lib/components/dashboard/cluster/overview/gpu-memory.svelte
+++ b/src/lib/components/dashboard/cluster/overview/gpu-memory.svelte
@@ -32,9 +32,9 @@
 	async function fetch() {
 		try {
 			const r = await fetchCombinedInstant(prometheusDriver, {
-				usage: `100 * sum(Device_memory_desc_of_container{}) / sum(GPUDeviceMemoryLimit{})`,
-				request: `100 * sum(vGPU_device_memory_limit_in_bytes{}) / sum(GPUDeviceMemoryLimit{})`,
-				allocatable: `sum(GPUDeviceMemoryLimit{})`
+				usage: `100 * sum(hami_container_device_memory_bytes{}) / sum(hami_gpu_memory_limit_bytes{})`,
+				request: `100 * sum(hami_vgpu_memory_limit_bytes{}) / sum(hami_gpu_memory_limit_bytes{})`,
+				allocatable: `sum(hami_gpu_memory_limit_bytes{})`
 			});
 			memoryUsage = r.usage[0]?.value ?? undefined;
 			memoryRequest = r.request[0]?.value ?? undefined;
@@ -120,15 +120,19 @@
 					tooltipContext={false}
 				>
 					{#snippet aboveMarks()}
-						{@const { value, unit } = formatCapacity(Number(allocatableMemory))}
+						{@const total = Number(allocatableMemory)}
+						{@const hasTotal = Number.isFinite(total)}
+						<!-- The card renders as soon as `usage` resolves, so the capacity from the other
+						     sub-query may still be missing. formatCapacity(NaN) would print "NaN KB". -->
+						{@const { value, unit } = formatCapacity(hasTotal ? total : 0)}
 						<Text
-							{value}
+							value={hasTotal ? value : '—'}
 							textAnchor="middle"
 							verticalAnchor="middle"
 							class="fill-foreground text-3xl! font-bold"
 						/>
 						<Text
-							value={unit}
+							value={hasTotal ? unit : ''}
 							textAnchor="middle"
 							verticalAnchor="middle"
 							class="fill-foreground text-xl! font-bold"

--- a/src/lib/components/dashboard/cluster/overview/gpu-utilization.svelte
+++ b/src/lib/components/dashboard/cluster/overview/gpu-utilization.svelte
@@ -22,11 +22,14 @@
 	let gpuUtilization: number | undefined = $state(undefined);
 	let units: number | undefined = $state(undefined);
 
-	// Both scalars come back in a single `or`-unioned instant query.
+	// Both scalars come back in a single `or`-unioned instant query. Both read DCGM, which
+	// reports per physical card — matching this card's "average across all GPU cards" framing
+	// and keeping the percentage consistent with the card count shown in the middle. HAMi's
+	// `hami_container_device_utilization_ratio` is per-container, so it double-counts a shared GPU.
 	async function fetch() {
 		try {
 			const r = await fetchCombinedInstant(prometheusDriver, {
-				utilization: `avg(Device_utilization_desc_of_container{})`,
+				utilization: `avg(DCGM_FI_DEV_GPU_UTIL{})`,
 				units: `count(DCGM_FI_DEV_GPU_UTIL{})`
 			});
 			gpuUtilization = r.utilization[0]?.value?.value ?? undefined;
@@ -111,8 +114,11 @@
 					tooltipContext={false}
 				>
 					{#snippet aboveMarks()}
+						<!-- The card gates on `utilization` alone, so the card count from the other
+						     sub-query may still be missing — String(undefined) would print "undefined". -->
+						{@const hasUnits = Number.isFinite(Number(units))}
 						<Text
-							value={String(units)}
+							value={hasUnits ? String(units) : '—'}
 							textAnchor="middle"
 							verticalAnchor="middle"
 							class="fill-foreground text-3xl! font-bold"

--- a/src/lib/components/dashboard/cluster/overview/node-pressure.svelte
+++ b/src/lib/components/dashboard/cluster/overview/node-pressure.svelte
@@ -60,7 +60,7 @@
 		}
 	}
 
-	// A workload (from the vGPU usage series' `podnamespace`/`podname`) sharing a GPU.
+	// A workload (from the vGPU usage series' pod labels) sharing a GPU.
 	type GpuConsumer = { namespace: string; pod: string; usage?: number };
 
 	// One physical GPU: `total` from DCGM, `usage`/`limit` from the vGPU exporter (undefined
@@ -113,9 +113,9 @@
 	const GPU_QUERIES = {
 		// Physical frame buffer per GPU → bytes (DCGM reports MiB). Labelled Hostname/UUID/modelName/device.
 		total: '(DCGM_FI_DEV_FB_FREE + DCGM_FI_DEV_FB_RESERVED + DCGM_FI_DEV_FB_USED) * (1024 * 1024)',
-		limit: 'sum by (deviceuuid) (vGPU_device_memory_limit_in_bytes)',
-		// Unaggregated so each series keeps `podnamespace`/`podname`; per-device sum is done in JS.
-		usage: 'vGPU_device_memory_usage_in_bytes'
+		limit: 'sum by (device_uuid) (hami_vgpu_memory_limit_bytes)',
+		// Unaggregated so each series keeps its owning pod's labels; per-device sum is done in JS.
+		usage: 'hami_vgpu_memory_used_bytes'
 	};
 
 	let rows = $state<NodeRow[]>([]);
@@ -161,7 +161,7 @@
 			const numberByDeviceUuid = (vectors: typeof limitResponse.result): Record<string, number> => {
 				const out: Record<string, number> = {};
 				for (const series of vectors) {
-					const uuid = (series.metric.labels as Record<string, string>).deviceuuid;
+					const uuid = (series.metric.labels as Record<string, string>).device_uuid;
 					const value = Number(series.value?.value);
 					if (uuid && Number.isFinite(value)) out[uuid] = value;
 				}
@@ -174,13 +174,15 @@
 			const consumersByUuid: Record<string, Record<string, GpuConsumer>> = {};
 			for (const series of usageResponse.result) {
 				const labels = series.metric.labels as Record<string, string>;
-				const uuid = labels.deviceuuid;
+				const uuid = labels.device_uuid;
 				if (!uuid) continue;
 				const value = Number(series.value?.value);
 				const usage = Number.isFinite(value) ? value : undefined;
 				if (usage !== undefined) usageByUuid[uuid] = (usageByUuid[uuid] ?? 0) + usage;
-				const namespace = labels.podnamespace ?? '';
-				const pod = labels.podname ?? '';
+				// The exporter's own `namespace`/`pod` labels win the scrape, so HAMi's workload
+				// labels arrive prefixed; fall back to the bare names for scrapes without honor_labels.
+				const namespace = labels.exported_namespace ?? labels.namespace ?? '';
+				const pod = labels.exported_pod ?? labels.pod ?? '';
 				if (!namespace && !pod) continue;
 				const byKey = (consumersByUuid[uuid] ??= {});
 				const key = `${namespace}/${pod}`;

--- a/src/lib/components/dashboard/model/analytics/a-top-p99-latency.svelte
+++ b/src/lib/components/dashboard/model/analytics/a-top-p99-latency.svelte
@@ -7,7 +7,9 @@
 	import { formatLatency } from '$lib/formatter';
 	import { m } from '$lib/messages';
 	import {
+		type ActivityState,
 		escapePromqlStringLiteral,
+		fetchCombinedInstant,
 		mergeVllmRowsById,
 		type VllmModelIdentity,
 		vllmModelIdentityFromLabels
@@ -27,14 +29,20 @@
 
 	let bars = $state<TopBar[]>([]);
 	let isLoaded = $state(false);
+	let activity = $state<ActivityState>('absent');
 
-	function buildQuery(): string {
+	function buildQueries(): Record<string, string> {
 		const ns = (namespace ?? '').trim();
 		const nsSel = ns ? `{namespace="${escapePromqlStringLiteral(ns)}"}` : '{}';
-		return (
-			`histogram_quantile(0.99, sum by(llm_inference_service, model_name, le) ` +
-			`(rate(vllm:e2e_request_latency_seconds_bucket${nsSel}[5m])))`
-		);
+		return {
+			p99:
+				`histogram_quantile(0.99, sum by(llm_inference_service, model_name, le) ` +
+				`(rate(vllm:e2e_request_latency_seconds_bucket${nsSel}[5m])))`,
+			// Rides along in the same combined query at no extra request: an idle model yields a
+			// flat 0 here, while one that was never scraped yields no series at all. Without it,
+			// every p99 is NaN and gets filtered out, leaving both cases indistinguishable.
+			traffic: `sum(rate(vllm:e2e_request_latency_seconds_count${nsSel}[5m]))`
+		};
 	}
 
 	function formatSeconds(value: number): string {
@@ -44,8 +52,10 @@
 
 	async function fetch() {
 		try {
-			const response = await prometheusDriver.instantQuery(buildQuery());
-			const parsed = response.result
+			const r = await fetchCombinedInstant(prometheusDriver, buildQueries());
+			const probe = Number(r.traffic[0]?.value?.value);
+			activity = !Number.isFinite(probe) ? 'absent' : probe > 0 ? 'active' : 'idle';
+			const parsed = r.p99
 				.map((v) => {
 					const identity = vllmModelIdentityFromLabels(v.metric.labels as Record<string, string>);
 					const value = Number(v.value?.value);
@@ -65,6 +75,7 @@
 			}));
 		} catch {
 			bars = [];
+			activity = 'absent';
 		}
 	}
 
@@ -87,6 +98,7 @@
 	tooltip={m.llm_dashboard_top_p99_latency_tooltip()}
 	{bars}
 	{isLoaded}
+	{activity}
 	onBarClick={onModelClick}
 	scrollable
 />

--- a/src/lib/components/dashboard/model/analytics/c-prefill-decode.svelte
+++ b/src/lib/components/dashboard/model/analytics/c-prefill-decode.svelte
@@ -2,6 +2,7 @@
 	import ChartLine from '@lucide/svelte/icons/chart-line';
 	import InfoIcon from '@lucide/svelte/icons/info';
 	import LoaderCircle from '@lucide/svelte/icons/loader-circle';
+	import MoonIcon from '@lucide/svelte/icons/moon';
 	import { scaleUtc } from 'd3-scale';
 	import { curveMonotoneX } from 'd3-shape';
 	import { Area, AreaChart, LinearGradient } from 'layerchart';
@@ -15,8 +16,10 @@
 	import * as Tooltip from '$lib/components/ui/tooltip';
 	import { m } from '$lib/messages';
 	import {
+		type ActivityState,
 		computeStep,
 		fetchMultipleFlattenedRange,
+		probeActivity,
 		vllmMetricWithSelector
 	} from '$lib/prometheus';
 
@@ -42,6 +45,7 @@
 
 	let data = $state<Row[]>([]);
 	let isLoaded = $state(false);
+	let activity = $state<ActivityState>('absent');
 
 	function queries() {
 		const prefillBucket = vllmMetricWithSelector(
@@ -54,9 +58,18 @@
 			namespace,
 			selectedModel
 		);
+		// Unlike the combined helpers, this one issues a request per query, so `traffic` costs an
+		// extra round trip. It earns it: without a probe, an idle model and one that was never
+		// scraped both collapse to the same empty chart.
+		const requests = vllmMetricWithSelector(
+			'vllm:request_prefill_time_seconds_count',
+			namespace,
+			selectedModel
+		);
 		return {
 			prefill: `histogram_quantile(0.95, sum by(le) (rate(${prefillBucket}[5m])))`,
-			decode: `histogram_quantile(0.95, sum by(le) (rate(${decodeBucket}[5m])))`
+			decode: `histogram_quantile(0.95, sum by(le) (rate(${decodeBucket}[5m])))`,
+			traffic: `sum(rate(${requests}[5m]))`
 		};
 	}
 
@@ -84,13 +97,19 @@
 				new Date(endMs),
 				step
 			);
-			data = points.map((p) => ({
-				date: p.date as Date,
-				prefill: Number.isFinite(Number(p.prefill)) ? Number(p.prefill) : 0,
-				decode: Number.isFinite(Number(p.decode)) ? Number(p.decode) : 0
-			}));
+			activity = probeActivity(points, 'traffic');
+			// A flat `traffic: 0` is a finite value, so it would keep points alive and defeat the
+			// `length === 0` empty check below — leaving a zero line that reads as measured zero.
+			data = points
+				.filter((p) => p.prefill !== undefined || p.decode !== undefined)
+				.map((p) => ({
+					date: p.date as Date,
+					prefill: Number.isFinite(Number(p.prefill)) ? Number(p.prefill) : 0,
+					decode: Number.isFinite(Number(p.decode)) ? Number(p.decode) : 0
+				}));
 		} catch {
 			data = [];
+			activity = 'absent';
 		}
 	}
 
@@ -132,9 +151,15 @@
 				<LoaderCircle class="size-12 animate-spin" />
 			</div>
 		{:else if data.length === 0}
-			<div class="flex h-[200px] w-full flex-col items-center justify-center">
-				<ChartLine class="size-12 animate-pulse text-muted-foreground" />
-				<p class="text-base text-muted-foreground">{m.no_data_display()}</p>
+			<div class="flex h-[200px] w-full flex-col items-center justify-center gap-1">
+				{#if activity === 'idle'}
+					<MoonIcon class="size-12 text-muted-foreground" />
+					<p class="text-base text-muted-foreground">{m.no_traffic_display()}</p>
+					<p class="text-xs text-muted-foreground">{m.no_traffic_hint()}</p>
+				{:else}
+					<ChartLine class="size-12 animate-pulse text-muted-foreground" />
+					<p class="text-base text-muted-foreground">{m.no_data_display()}</p>
+				{/if}
 			</div>
 		{:else}
 			<Chart.Container config={configuration} class="h-[200px] w-full">

--- a/src/lib/components/dashboard/model/analytics/c-prefix-cache-hit.svelte
+++ b/src/lib/components/dashboard/model/analytics/c-prefix-cache-hit.svelte
@@ -2,6 +2,7 @@
 	import ChartLine from '@lucide/svelte/icons/chart-line';
 	import InfoIcon from '@lucide/svelte/icons/info';
 	import LoaderCircle from '@lucide/svelte/icons/loader-circle';
+	import MoonIcon from '@lucide/svelte/icons/moon';
 	import { scaleUtc } from 'd3-scale';
 	import { curveMonotoneX } from 'd3-shape';
 	import { Area, AreaChart, LinearGradient } from 'layerchart';
@@ -15,8 +16,10 @@
 	import * as Tooltip from '$lib/components/ui/tooltip';
 	import { m } from '$lib/messages';
 	import {
+		type ActivityState,
 		computeStep,
 		fetchMultipleFlattenedRange,
+		probeActivity,
 		vllmMetricWithSelector
 	} from '$lib/prometheus';
 
@@ -47,6 +50,7 @@
 	let hasL2 = $state(false);
 	let hasL3 = $state(false);
 	let isLoaded = $state(false);
+	let activity = $state<ActivityState>('absent');
 
 	function queries(): Record<string, string> {
 		const l1Hits = vllmMetricWithSelector('vllm:prefix_cache_hits_total', namespace, selectedModel);
@@ -74,7 +78,11 @@
 		return {
 			l1: `sum(rate(${l1Hits}[5m])) / sum(rate(${l1Queries}[5m])) * 100`,
 			l2: `sum(rate(${l2Hits}[5m])) / sum(rate(${l2Requested}[5m])) * 100`,
-			l3: `sum(rate(${l3Hits}[5m])) / sum(rate(${l3Queries}[5m])) * 100`
+			l3: `sum(rate(${l3Hits}[5m])) / sum(rate(${l3Queries}[5m])) * 100`,
+			// Every tier is a hit/query ratio, so an idle model divides 0 by 0 and yields NaN for
+			// all three. The L1 denominator alone survives that: flat 0 when nothing is served,
+			// no series at all when vLLM is not scraped.
+			traffic: `sum(rate(${l1Queries}[5m]))`
 		};
 	}
 
@@ -95,12 +103,18 @@
 		try {
 			const startMs = start.getTime();
 			const endMs = endIsNow ? Date.now() : end.getTime();
-			const points = await fetchMultipleFlattenedRange(
+			const raw = await fetchMultipleFlattenedRange(
 				prometheusDriver,
 				queries(),
 				new Date(startMs),
 				new Date(endMs),
 				computeStep(startMs, endMs)
+			);
+			activity = probeActivity(raw, 'traffic');
+			// A flat `traffic: 0` is finite and would keep points alive, defeating the
+			// `length === 0` empty check and drawing a 0% line that reads as a measured miss rate.
+			const points = raw.filter(
+				(p) => p.l1 !== undefined || p.l2 !== undefined || p.l3 !== undefined
 			);
 			hasL2 = points.some((p) => Number.isFinite(Number(p.l2)));
 			hasL3 = points.some((p) => Number.isFinite(Number(p.l3)));
@@ -112,6 +126,7 @@
 			}));
 		} catch {
 			data = [];
+			activity = 'absent';
 			hasL2 = false;
 			hasL3 = false;
 		}
@@ -167,9 +182,15 @@
 				<LoaderCircle class="size-12 animate-spin" />
 			</div>
 		{:else if data.length === 0}
-			<div class="flex h-[200px] w-full flex-col items-center justify-center">
-				<ChartLine class="size-12 animate-pulse text-muted-foreground" />
-				<p class="text-base text-muted-foreground">{m.no_data_display()}</p>
+			<div class="flex h-[200px] w-full flex-col items-center justify-center gap-1">
+				{#if activity === 'idle'}
+					<MoonIcon class="size-12 text-muted-foreground" />
+					<p class="text-base text-muted-foreground">{m.no_traffic_display()}</p>
+					<p class="text-xs text-muted-foreground">{m.no_traffic_hint()}</p>
+				{:else}
+					<ChartLine class="size-12 animate-pulse text-muted-foreground" />
+					<p class="text-base text-muted-foreground">{m.no_data_display()}</p>
+				{/if}
 			</div>
 		{:else}
 			<Chart.Container config={configuration} class="h-[200px] w-full">

--- a/src/lib/components/dashboard/model/analytics/c-token-size-distribution.svelte
+++ b/src/lib/components/dashboard/model/analytics/c-token-size-distribution.svelte
@@ -2,6 +2,7 @@
 	import ChartLine from '@lucide/svelte/icons/chart-line';
 	import InfoIcon from '@lucide/svelte/icons/info';
 	import LoaderCircle from '@lucide/svelte/icons/loader-circle';
+	import MoonIcon from '@lucide/svelte/icons/moon';
 	import { scaleBand, scaleLinear } from 'd3-scale';
 	import { Axis, Cell, Chart as LayerChart, Svg, Tooltip as LayerTooltip } from 'layerchart';
 	import { PrometheusDriver } from 'prometheus-query';
@@ -15,6 +16,7 @@
 	import * as Tooltip from '$lib/components/ui/tooltip';
 	import { m } from '$lib/messages';
 	import {
+		type ActivityState,
 		computeStep,
 		type DataPoint,
 		fetchFlattenedRange,
@@ -164,6 +166,14 @@
 	const yDomain = $derived(sortedBuckets.map((b) => b.label));
 	const hasData = $derived(cells.some((c) => c.value > 0));
 
+	// No probe query needed — the bucket series are their own signal. Series present but every
+	// cell zero means the model is up and served nothing; no series at all means nothing is
+	// deployed or scraped. Collapsing both into "no data" hides a healthy model behind the
+	// same message as a broken one.
+	const activity = $derived<ActivityState>(
+		rawData.length === 0 || sortedBuckets.length === 0 ? 'absent' : hasData ? 'active' : 'idle'
+	);
+
 	const cellLookup = $derived.by(() => {
 		const map = new SvelteMap<string, HeatCell>();
 		for (const c of cells) map.set(`${c.dateKey}|${c.bucketLabel}`, c);
@@ -213,9 +223,15 @@
 				<LoaderCircle class="size-12 animate-spin" />
 			</div>
 		{:else if !hasData || sortedBuckets.length === 0}
-			<div class="flex h-[200px] w-full flex-col items-center justify-center">
-				<ChartLine class="size-12 animate-pulse text-muted-foreground" />
-				<p class="text-base text-muted-foreground">{m.no_data_display()}</p>
+			<div class="flex h-[200px] w-full flex-col items-center justify-center gap-1">
+				{#if activity === 'idle'}
+					<MoonIcon class="size-12 text-muted-foreground" />
+					<p class="text-base text-muted-foreground">{m.no_traffic_display()}</p>
+					<p class="text-xs text-muted-foreground">{m.no_traffic_hint()}</p>
+				{:else}
+					<ChartLine class="size-12 animate-pulse text-muted-foreground" />
+					<p class="text-base text-muted-foreground">{m.no_data_display()}</p>
+				{/if}
 			</div>
 		{:else}
 			<Chart.Container config={chartConfig} class="h-[200px] w-full">

--- a/src/lib/components/dashboard/model/analytics/d-time-per-output-token.svelte
+++ b/src/lib/components/dashboard/model/analytics/d-time-per-output-token.svelte
@@ -2,6 +2,7 @@
 	import ChartLine from '@lucide/svelte/icons/chart-line';
 	import InfoIcon from '@lucide/svelte/icons/info';
 	import LoaderCircle from '@lucide/svelte/icons/loader-circle';
+	import MoonIcon from '@lucide/svelte/icons/moon';
 	import { scaleUtc } from 'd3-scale';
 	import { curveMonotoneX } from 'd3-shape';
 	import { Area, AreaChart, LinearGradient } from 'layerchart';
@@ -15,9 +16,11 @@
 	import * as Tooltip from '$lib/components/ui/tooltip';
 	import { m } from '$lib/messages';
 	import {
+		type ActivityState,
 		computeStep,
 		type DataPoint,
 		fetchCombinedFlattenedRange,
+		probeActivity,
 		vllmMetricWithSelector
 	} from '$lib/prometheus';
 
@@ -42,6 +45,7 @@
 	} = $props();
 
 	let times_per_output_token = $state<DataPoint[]>([]);
+	let activity = $state<ActivityState>('absent');
 
 	function tpotQueries(): Record<string, string> {
 		const bucket = vllmMetricWithSelector(
@@ -50,9 +54,17 @@
 			selectedModel
 		);
 		const inner = `sum by(le) (rate(${bucket}[5m]))`;
+		// `traffic` rides along in the same combined query at no extra request. It tells an
+		// idle model (series present, flat 0) apart from one that was never scraped (no series).
+		const requests = vllmMetricWithSelector(
+			'vllm:request_time_per_output_token_seconds_count',
+			namespace,
+			selectedModel
+		);
 		return {
 			p95: `histogram_quantile(0.95, ${inner})`,
-			p99: `histogram_quantile(0.99, ${inner})`
+			p99: `histogram_quantile(0.99, ${inner})`,
+			traffic: `sum(rate(${requests}[5m]))`
 		};
 	}
 
@@ -73,15 +85,20 @@
 			const startMs = start.getTime();
 			const endMs = endIsNow ? Date.now() : end.getTime();
 			const step = computeStep(startMs, endMs);
-			times_per_output_token = await fetchCombinedFlattenedRange(
+			const points = await fetchCombinedFlattenedRange(
 				prometheusDriver,
 				tpotQueries(),
 				new Date(startMs),
 				new Date(endMs),
 				step
 			);
+			activity = probeActivity(points, 'traffic');
+			// A flat `traffic: 0` is a finite value, so it would keep points alive and defeat the
+			// `length === 0` empty check below. Only quantile-bearing points are plottable.
+			times_per_output_token = points.filter((p) => p.p95 !== undefined || p.p99 !== undefined);
 		} catch (error) {
 			times_per_output_token = [];
+			activity = 'absent';
 			console.error(`Fail to fetch time per output token data in cluster ${cluster}:`, error);
 		}
 	}
@@ -125,9 +142,15 @@
 				<LoaderCircle class="size-12 animate-spin" />
 			</div>
 		{:else if times_per_output_token.length === 0}
-			<div class="flex h-[200px] w-full flex-col items-center justify-center">
-				<ChartLine class="size-12 animate-pulse text-muted-foreground" />
-				<p class="text-base text-muted-foreground">{m.no_data_display()}</p>
+			<div class="flex h-[200px] w-full flex-col items-center justify-center gap-1">
+				{#if activity === 'idle'}
+					<MoonIcon class="size-12 text-muted-foreground" />
+					<p class="text-base text-muted-foreground">{m.no_traffic_display()}</p>
+					<p class="text-xs text-muted-foreground">{m.no_traffic_hint()}</p>
+				{:else}
+					<ChartLine class="size-12 animate-pulse text-muted-foreground" />
+					<p class="text-base text-muted-foreground">{m.no_data_display()}</p>
+				{/if}
 			</div>
 		{:else}
 			<Chart.Container config={configuration} class="h-[200px] w-full">

--- a/src/lib/components/dashboard/model/analytics/d-time-to-first-token.svelte
+++ b/src/lib/components/dashboard/model/analytics/d-time-to-first-token.svelte
@@ -2,6 +2,7 @@
 	import ChartLine from '@lucide/svelte/icons/chart-line';
 	import InfoIcon from '@lucide/svelte/icons/info';
 	import LoaderCircle from '@lucide/svelte/icons/loader-circle';
+	import MoonIcon from '@lucide/svelte/icons/moon';
 	import { scaleUtc } from 'd3-scale';
 	import { curveMonotoneX } from 'd3-shape';
 	import { Area, AreaChart, LinearGradient } from 'layerchart';
@@ -15,9 +16,11 @@
 	import * as Tooltip from '$lib/components/ui/tooltip';
 	import { m } from '$lib/messages';
 	import {
+		type ActivityState,
 		computeStep,
 		type DataPoint,
 		fetchCombinedFlattenedRange,
+		probeActivity,
 		vllmMetricWithSelector
 	} from '$lib/prometheus';
 
@@ -42,6 +45,7 @@
 	} = $props();
 
 	let times_to_first_token = $state<DataPoint[]>([]);
+	let activity = $state<ActivityState>('absent');
 
 	function ttftQueries(): Record<string, string> {
 		const bucket = vllmMetricWithSelector(
@@ -50,9 +54,17 @@
 			selectedModel
 		);
 		const inner = `sum by(le) (rate(${bucket}[5m]))`;
+		// `traffic` rides along in the same combined query at no extra request. It tells an
+		// idle model (series present, flat 0) apart from one that was never scraped (no series).
+		const requests = vllmMetricWithSelector(
+			'vllm:time_to_first_token_seconds_count',
+			namespace,
+			selectedModel
+		);
 		return {
 			p95: `histogram_quantile(0.95, ${inner})`,
-			p99: `histogram_quantile(0.99, ${inner})`
+			p99: `histogram_quantile(0.99, ${inner})`,
+			traffic: `sum(rate(${requests}[5m]))`
 		};
 	}
 
@@ -73,15 +85,20 @@
 			const startMs = start.getTime();
 			const endMs = endIsNow ? Date.now() : end.getTime();
 			const step = computeStep(startMs, endMs);
-			times_to_first_token = await fetchCombinedFlattenedRange(
+			const points = await fetchCombinedFlattenedRange(
 				prometheusDriver,
 				ttftQueries(),
 				new Date(startMs),
 				new Date(endMs),
 				step
 			);
+			activity = probeActivity(points, 'traffic');
+			// A flat `traffic: 0` is a finite value, so it would keep points alive and defeat the
+			// `length === 0` empty check below. Only quantile-bearing points are plottable.
+			times_to_first_token = points.filter((p) => p.p95 !== undefined || p.p99 !== undefined);
 		} catch (error) {
 			times_to_first_token = [];
+			activity = 'absent';
 			console.error(`Fail to fetch time to first token data in cluster ${cluster}:`, error);
 		}
 	}
@@ -125,9 +142,15 @@
 				<LoaderCircle class="size-12 animate-spin" />
 			</div>
 		{:else if times_to_first_token.length === 0}
-			<div class="flex h-[200px] w-full flex-col items-center justify-center">
-				<ChartLine class="size-12 animate-pulse text-muted-foreground" />
-				<p class="text-base text-muted-foreground">{m.no_data_display()}</p>
+			<div class="flex h-[200px] w-full flex-col items-center justify-center gap-1">
+				{#if activity === 'idle'}
+					<MoonIcon class="size-12 text-muted-foreground" />
+					<p class="text-base text-muted-foreground">{m.no_traffic_display()}</p>
+					<p class="text-xs text-muted-foreground">{m.no_traffic_hint()}</p>
+				{:else}
+					<ChartLine class="size-12 animate-pulse text-muted-foreground" />
+					<p class="text-base text-muted-foreground">{m.no_data_display()}</p>
+				{/if}
 			</div>
 		{:else}
 			<Chart.Container config={configuration} class="h-[200px] w-full">

--- a/src/lib/components/dashboard/model/overview/cache-tiers.svelte
+++ b/src/lib/components/dashboard/model/overview/cache-tiers.svelte
@@ -2,6 +2,7 @@
 	import ChartLineIcon from '@lucide/svelte/icons/chart-line';
 	import InfoIcon from '@lucide/svelte/icons/info';
 	import Loader2Icon from '@lucide/svelte/icons/loader-2';
+	import MoonIcon from '@lucide/svelte/icons/moon';
 	import { scaleUtc } from 'd3-scale';
 	import { curveMonotoneX } from 'd3-shape';
 	import { Area, AreaChart, LinearGradient } from 'layerchart';
@@ -15,8 +16,10 @@
 	import * as Tooltip from '$lib/components/ui/tooltip';
 	import { m } from '$lib/messages';
 	import {
+		type ActivityState,
 		computeStep,
 		fetchMultipleFlattenedRange,
+		probeActivity,
 		vllmMetricWithSelector
 	} from '$lib/prometheus';
 
@@ -47,6 +50,7 @@
 	let hasL2 = $state(false);
 	let hasL3 = $state(false);
 	let isLoaded = $state(false);
+	let activity = $state<ActivityState>('absent');
 
 	const configuration = {
 		l1: { label: m.cache_l1_vllm(), color: 'var(--chart-2)' },
@@ -88,7 +92,11 @@
 		return {
 			l1: `sum(rate(${l1Hits}[5m])) / sum(rate(${l1Queries}[5m])) * 100`,
 			l2: `sum(rate(${l2Hits}[5m])) / sum(rate(${l2Requested}[5m])) * 100`,
-			l3: `sum(rate(${l3Hits}[5m])) / sum(rate(${l3Queries}[5m])) * 100`
+			l3: `sum(rate(${l3Hits}[5m])) / sum(rate(${l3Queries}[5m])) * 100`,
+			// Every tier is a hit/query ratio, so an idle model divides 0 by 0 and yields NaN for
+			// all three. The L1 denominator alone survives that: flat 0 when nothing is served,
+			// no series at all when vLLM is not scraped.
+			traffic: `sum(rate(${l1Queries}[5m]))`
 		};
 	}
 
@@ -96,12 +104,18 @@
 		try {
 			const startMs = start.getTime();
 			const endMs = endIsNow ? Date.now() : end.getTime();
-			const points = await fetchMultipleFlattenedRange(
+			const raw = await fetchMultipleFlattenedRange(
 				prometheusDriver,
 				queries(),
 				new Date(startMs),
 				new Date(endMs),
 				computeStep(startMs, endMs)
+			);
+			activity = probeActivity(raw, 'traffic');
+			// A flat `traffic: 0` is finite and would keep points alive, defeating the
+			// `length === 0` empty check and drawing a 0% line that reads as a measured miss rate.
+			const points = raw.filter(
+				(p) => p.l1 !== undefined || p.l2 !== undefined || p.l3 !== undefined
 			);
 			hasL2 = points.some((p) => Number.isFinite(Number(p.l2)));
 			hasL3 = points.some((p) => Number.isFinite(Number(p.l3)));
@@ -113,6 +127,7 @@
 			}));
 		} catch (error) {
 			data = [];
+			activity = 'absent';
 			hasL2 = false;
 			hasL3 = false;
 			console.error(`Fail to fetch cache tiers in cluster ${cluster}:`, error);
@@ -168,9 +183,15 @@
 		</Card.Content>
 	{:else if data.length === 0}
 		<Card.Content>
-			<div class="flex h-45 w-full flex-col items-center justify-center gap-2">
-				<ChartLineIcon class="size-12 animate-pulse text-muted-foreground" />
-				<p class="text-sm text-muted-foreground">{m.no_data_display()}</p>
+			<div class="flex h-45 w-full flex-col items-center justify-center gap-1">
+				{#if activity === 'idle'}
+					<MoonIcon class="size-12 text-muted-foreground" />
+					<p class="text-sm text-muted-foreground">{m.no_traffic_display()}</p>
+					<p class="text-xs text-muted-foreground">{m.no_traffic_hint()}</p>
+				{:else}
+					<ChartLineIcon class="size-12 animate-pulse text-muted-foreground" />
+					<p class="text-sm text-muted-foreground">{m.no_data_display()}</p>
+				{/if}
 			</div>
 		</Card.Content>
 	{:else}

--- a/src/lib/components/dashboard/model/overview/e2e-latency.svelte
+++ b/src/lib/components/dashboard/model/overview/e2e-latency.svelte
@@ -2,6 +2,7 @@
 	import ChartLineIcon from '@lucide/svelte/icons/chart-line';
 	import InfoIcon from '@lucide/svelte/icons/info';
 	import Loader2Icon from '@lucide/svelte/icons/loader-2';
+	import MoonIcon from '@lucide/svelte/icons/moon';
 	import { scaleUtc } from 'd3-scale';
 	import { curveMonotoneX } from 'd3-shape';
 	import { Area, AreaChart, LinearGradient } from 'layerchart';
@@ -15,9 +16,11 @@
 	import * as Tooltip from '$lib/components/ui/tooltip';
 	import { m } from '$lib/messages';
 	import {
+		type ActivityState,
 		computeStep,
 		type DataPoint,
 		fetchCombinedFlattenedRange,
+		probeActivity,
 		vllmMetricWithSelector
 	} from '$lib/prometheus';
 
@@ -40,6 +43,7 @@
 	} = $props();
 
 	let requestLatencies = $state<DataPoint[]>([]);
+	let activity = $state<ActivityState>('absent');
 
 	function latencyQueries(): Record<string, string> {
 		const inner = vllmMetricWithSelector(
@@ -48,9 +52,17 @@
 			undefined
 		);
 		const rate = `sum by(le) (rate(${inner}[5m]))`;
+		// `traffic` rides along in the same combined query at no extra request. It tells an
+		// idle model (series present, flat 0) apart from one that was never scraped (no series).
+		const requests = vllmMetricWithSelector(
+			'vllm:e2e_request_latency_seconds_count',
+			namespace,
+			undefined
+		);
 		return {
 			p95: `histogram_quantile(0.95, ${rate})`,
-			p99: `histogram_quantile(0.99, ${rate})`
+			p99: `histogram_quantile(0.99, ${rate})`,
+			traffic: `sum(rate(${requests}[5m]))`
 		};
 	}
 
@@ -71,15 +83,20 @@
 			const startMs = start.getTime();
 			const endMs = endIsNow ? Date.now() : end.getTime();
 			const step = computeStep(startMs, endMs);
-			requestLatencies = await fetchCombinedFlattenedRange(
+			const points = await fetchCombinedFlattenedRange(
 				prometheusDriver,
 				latencyQueries(),
 				new Date(startMs),
 				new Date(endMs),
 				step
 			);
+			activity = probeActivity(points, 'traffic');
+			// A flat `traffic: 0` is a finite value, so it would keep points alive and defeat the
+			// `length === 0` empty check below. Only quantile-bearing points are plottable.
+			requestLatencies = points.filter((p) => p.p95 !== undefined || p.p99 !== undefined);
 		} catch (error) {
 			requestLatencies = [];
+			activity = 'absent';
 			console.error(`Fail to fetch e2e latency in cluster ${cluster}:`, error);
 		}
 	}
@@ -132,8 +149,14 @@
 	{:else if requestLatencies.length === 0}
 		<Card.Content>
 			<div class="flex h-45 w-full flex-col items-center justify-center gap-2">
-				<ChartLineIcon class="size-12 animate-pulse text-muted-foreground" />
-				<p class="text-sm text-muted-foreground">{m.no_data_display()}</p>
+				{#if activity === 'idle'}
+					<MoonIcon class="size-12 text-muted-foreground" />
+					<p class="text-sm text-muted-foreground">{m.no_traffic_display()}</p>
+					<p class="text-xs text-muted-foreground">{m.no_traffic_hint()}</p>
+				{:else}
+					<ChartLineIcon class="size-12 animate-pulse text-muted-foreground" />
+					<p class="text-sm text-muted-foreground">{m.no_data_display()}</p>
+				{/if}
 			</div>
 		</Card.Content>
 	{:else}
@@ -188,11 +211,11 @@
 										<span class="text-muted-foreground">{name}</span>
 									</div>
 									<span class="font-mono font-medium text-foreground tabular-nums">
-										{#if value}
+										{#if Number.isFinite(Number(value))}
 											{Number(value).toFixed(2)}
 											{m.second()}
 										{:else}
-											NaN
+											&mdash;
 										{/if}
 									</span>
 								</div>

--- a/src/lib/components/dashboard/model/overview/time-per-output-token.svelte
+++ b/src/lib/components/dashboard/model/overview/time-per-output-token.svelte
@@ -2,6 +2,7 @@
 	import ChartLineIcon from '@lucide/svelte/icons/chart-line';
 	import InfoIcon from '@lucide/svelte/icons/info';
 	import Loader2Icon from '@lucide/svelte/icons/loader-2';
+	import MoonIcon from '@lucide/svelte/icons/moon';
 	import { scaleUtc } from 'd3-scale';
 	import { curveMonotoneX } from 'd3-shape';
 	import { Area, AreaChart, LinearGradient } from 'layerchart';
@@ -15,9 +16,11 @@
 	import * as Tooltip from '$lib/components/ui/tooltip';
 	import { m } from '$lib/messages';
 	import {
+		type ActivityState,
 		computeStep,
 		type DataPoint,
 		fetchCombinedFlattenedRange,
+		probeActivity,
 		vllmMetricWithSelector
 	} from '$lib/prometheus';
 
@@ -40,6 +43,7 @@
 	} = $props();
 
 	let times_per_output_token = $state<DataPoint[]>([]);
+	let activity = $state<ActivityState>('absent');
 
 	function tpotQueries(): Record<string, string> {
 		const inner = vllmMetricWithSelector(
@@ -48,9 +52,17 @@
 			undefined
 		);
 		const rate = `sum by(le) (rate(${inner}[5m]))`;
+		// `traffic` rides along in the same combined query at no extra request. It tells an
+		// idle model (series present, flat 0) apart from one that was never scraped (no series).
+		const requests = vllmMetricWithSelector(
+			'vllm:request_time_per_output_token_seconds_count',
+			namespace,
+			undefined
+		);
 		return {
 			p95: `histogram_quantile(0.95, ${rate})`,
-			p99: `histogram_quantile(0.99, ${rate})`
+			p99: `histogram_quantile(0.99, ${rate})`,
+			traffic: `sum(rate(${requests}[5m]))`
 		};
 	}
 
@@ -71,15 +83,20 @@
 			const startMs = start.getTime();
 			const endMs = endIsNow ? Date.now() : end.getTime();
 			const step = computeStep(startMs, endMs);
-			times_per_output_token = await fetchCombinedFlattenedRange(
+			const points = await fetchCombinedFlattenedRange(
 				prometheusDriver,
 				tpotQueries(),
 				new Date(startMs),
 				new Date(endMs),
 				step
 			);
+			activity = probeActivity(points, 'traffic');
+			// A flat `traffic: 0` is a finite value, so it would keep points alive and defeat the
+			// `length === 0` empty check below. Only quantile-bearing points are plottable.
+			times_per_output_token = points.filter((p) => p.p95 !== undefined || p.p99 !== undefined);
 		} catch (error) {
 			times_per_output_token = [];
+			activity = 'absent';
 			console.error(`Fail to fetch time per output token data in cluster ${cluster}:`, error);
 		}
 	}
@@ -132,8 +149,14 @@
 	{:else if times_per_output_token.length === 0}
 		<Card.Content>
 			<div class="flex h-45 w-full flex-col items-center justify-center gap-2">
-				<ChartLineIcon class="size-12 animate-pulse text-muted-foreground" />
-				<p class="text-sm text-muted-foreground">{m.no_data_display()}</p>
+				{#if activity === 'idle'}
+					<MoonIcon class="size-12 text-muted-foreground" />
+					<p class="text-sm text-muted-foreground">{m.no_traffic_display()}</p>
+					<p class="text-xs text-muted-foreground">{m.no_traffic_hint()}</p>
+				{:else}
+					<ChartLineIcon class="size-12 animate-pulse text-muted-foreground" />
+					<p class="text-sm text-muted-foreground">{m.no_data_display()}</p>
+				{/if}
 			</div>
 		</Card.Content>
 	{:else}

--- a/src/lib/components/dashboard/model/overview/time-to-first-token.svelte
+++ b/src/lib/components/dashboard/model/overview/time-to-first-token.svelte
@@ -2,6 +2,7 @@
 	import ChartLineIcon from '@lucide/svelte/icons/chart-line';
 	import InfoIcon from '@lucide/svelte/icons/info';
 	import Loader2Icon from '@lucide/svelte/icons/loader-2';
+	import MoonIcon from '@lucide/svelte/icons/moon';
 	import { scaleUtc } from 'd3-scale';
 	import { curveMonotoneX } from 'd3-shape';
 	import { Area, AreaChart, LinearGradient } from 'layerchart';
@@ -15,9 +16,11 @@
 	import * as Tooltip from '$lib/components/ui/tooltip';
 	import { m } from '$lib/messages';
 	import {
+		type ActivityState,
 		computeStep,
 		type DataPoint,
 		fetchCombinedFlattenedRange,
+		probeActivity,
 		vllmMetricWithSelector
 	} from '$lib/prometheus';
 
@@ -40,6 +43,7 @@
 	} = $props();
 
 	let times_to_first_token = $state<DataPoint[]>([]);
+	let activity = $state<ActivityState>('absent');
 
 	function ttftQueries(): Record<string, string> {
 		const inner = vllmMetricWithSelector(
@@ -48,9 +52,17 @@
 			undefined
 		);
 		const rate = `sum by(le) (rate(${inner}[5m]))`;
+		// `traffic` rides along in the same combined query at no extra request. It tells an
+		// idle model (series present, flat 0) apart from one that was never scraped (no series).
+		const requests = vllmMetricWithSelector(
+			'vllm:time_to_first_token_seconds_count',
+			namespace,
+			undefined
+		);
 		return {
 			p95: `histogram_quantile(0.95, ${rate})`,
-			p99: `histogram_quantile(0.99, ${rate})`
+			p99: `histogram_quantile(0.99, ${rate})`,
+			traffic: `sum(rate(${requests}[5m]))`
 		};
 	}
 
@@ -71,15 +83,20 @@
 			const startMs = start.getTime();
 			const endMs = endIsNow ? Date.now() : end.getTime();
 			const step = computeStep(startMs, endMs);
-			times_to_first_token = await fetchCombinedFlattenedRange(
+			const points = await fetchCombinedFlattenedRange(
 				prometheusDriver,
 				ttftQueries(),
 				new Date(startMs),
 				new Date(endMs),
 				step
 			);
+			activity = probeActivity(points, 'traffic');
+			// A flat `traffic: 0` is a finite value, so it would keep points alive and defeat the
+			// `length === 0` empty check below. Only quantile-bearing points are plottable.
+			times_to_first_token = points.filter((p) => p.p95 !== undefined || p.p99 !== undefined);
 		} catch (error) {
 			times_to_first_token = [];
+			activity = 'absent';
 			console.error(`Fail to fetch time to first token data in cluster ${cluster}:`, error);
 		}
 	}
@@ -132,8 +149,14 @@
 	{:else if times_to_first_token.length === 0}
 		<Card.Content>
 			<div class="flex h-45 w-full flex-col items-center justify-center gap-2">
-				<ChartLineIcon class="size-12 animate-pulse text-muted-foreground" />
-				<p class="text-sm text-muted-foreground">{m.no_data_display()}</p>
+				{#if activity === 'idle'}
+					<MoonIcon class="size-12 text-muted-foreground" />
+					<p class="text-sm text-muted-foreground">{m.no_traffic_display()}</p>
+					<p class="text-xs text-muted-foreground">{m.no_traffic_hint()}</p>
+				{:else}
+					<ChartLineIcon class="size-12 animate-pulse text-muted-foreground" />
+					<p class="text-sm text-muted-foreground">{m.no_data_display()}</p>
+				{/if}
 			</div>
 		</Card.Content>
 	{:else}

--- a/src/lib/components/kind-viewer/kind-viewer-actions/utils/gpu-resources.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/utils/gpu-resources.svelte
@@ -27,8 +27,8 @@
 			driver.instantQuery(
 				'(DCGM_FI_DEV_FB_FREE + DCGM_FI_DEV_FB_RESERVED + DCGM_FI_DEV_FB_USED) * (1024 * 1024)' // DCGM return in Mi
 			),
-			driver.instantQuery('sum by (deviceuuid) (vGPU_device_memory_limit_in_bytes)'),
-			driver.instantQuery('sum by (deviceuuid) (vGPU_device_memory_usage_in_bytes)')
+			driver.instantQuery('sum by (device_uuid) (hami_vgpu_memory_limit_bytes)'),
+			driver.instantQuery('sum by (device_uuid) (hami_vgpu_memory_used_bytes)')
 		]);
 
 		const vgpuLimits = vgpuLimitResponse.result.map((series) => {
@@ -38,10 +38,10 @@
 			return { ...series.metric.labels, usage: series.value?.value };
 		});
 
-		const limitsByDeviceUUID = lodash.mapValues(lodash.groupBy(vgpuLimits, 'deviceuuid'), (group) =>
+		const limitsByDeviceUUID = lodash.mapValues(lodash.groupBy(vgpuLimits, 'device_uuid'), (group) =>
 			lodash.sumBy(group, 'limit')
 		);
-		const usagesByDeviceUUID = lodash.mapValues(lodash.groupBy(vgpuUsages, 'deviceuuid'), (group) =>
+		const usagesByDeviceUUID = lodash.mapValues(lodash.groupBy(vgpuUsages, 'device_uuid'), (group) =>
 			lodash.sumBy(group, 'usage')
 		);
 

--- a/src/lib/components/kind-viewer/kind-viewer-actions/utils/gpu-resources.svelte
+++ b/src/lib/components/kind-viewer/kind-viewer-actions/utils/gpu-resources.svelte
@@ -38,11 +38,13 @@
 			return { ...series.metric.labels, usage: series.value?.value };
 		});
 
-		const limitsByDeviceUUID = lodash.mapValues(lodash.groupBy(vgpuLimits, 'device_uuid'), (group) =>
-			lodash.sumBy(group, 'limit')
+		const limitsByDeviceUUID = lodash.mapValues(
+			lodash.groupBy(vgpuLimits, 'device_uuid'),
+			(group) => lodash.sumBy(group, 'limit')
 		);
-		const usagesByDeviceUUID = lodash.mapValues(lodash.groupBy(vgpuUsages, 'device_uuid'), (group) =>
-			lodash.sumBy(group, 'usage')
+		const usagesByDeviceUUID = lodash.mapValues(
+			lodash.groupBy(vgpuUsages, 'device_uuid'),
+			(group) => lodash.sumBy(group, 'usage')
 		);
 
 		gpus = fieldBufferResponse.result.map((series) => {

--- a/src/lib/prometheus.ts
+++ b/src/lib/prometheus.ts
@@ -214,6 +214,32 @@ export function thresholdChartColor(level: ThresholdLevel): string {
 
 export type DataPoint = Record<string, Date | number>;
 
+/**
+ * Why a panel has nothing to draw. `absent` means the metric family produced no series
+ * at all (nothing deployed, or not being scraped); `idle` means the series exist but the
+ * workload saw no requests in the window. Collapsing both into "no data" hides a working
+ * deployment behind the same message as a broken one.
+ */
+export type ActivityState = 'absent' | 'idle' | 'active';
+
+/**
+ * Classify a panel from a probe series — typically `sum(rate(<histogram>_count[5m]))`,
+ * which yields no series when the metric is absent and a flat 0 when nothing is served.
+ * Ride the probe along in the same combined query so it costs no extra request, then keep
+ * it out of the chart data: a constant 0 is a valid data point and would defeat the
+ * caller's `length === 0` empty check.
+ */
+export function probeActivity(points: DataPoint[], key: string): ActivityState {
+	let present = false;
+	for (const point of points) {
+		const value = Number(point[key]);
+		if (!Number.isFinite(value)) continue;
+		present = true;
+		if (value > 0) return 'active';
+	}
+	return present ? 'idle' : 'absent';
+}
+
 const CHART_COLORS = ['chart-1', 'chart-2', 'chart-3', 'chart-4', 'chart-5'];
 
 function getLabelKey(vec: RangeVector): string {
@@ -234,6 +260,24 @@ function getLabelKey(vec: RangeVector): string {
 }
 
 /**
+ * Record one sample under `key` in the flattened per-timestamp map, dropping values that
+ * are not finite. `histogram_quantile` over an idle histogram returns NaN (0/0 during
+ * interpolation), and NaN is not plottable — keeping it renders an empty chart whose
+ * tooltips read "NaN". Dropping it lets callers fall back to their own empty state.
+ */
+function putSample(
+	dateMap: Map<number, DataPoint>,
+	key: string,
+	sample: RangeVector['values'][number]
+) {
+	const value = Number(sample.value);
+	if (!Number.isFinite(value)) return;
+	const time = (sample.time as Date).getTime();
+	if (!dateMap.has(time)) dateMap.set(time, { date: sample.time as Date });
+	dateMap.get(time)![key] = value;
+}
+
+/**
  * Run a single range query that may return multiple labelled series (e.g. `sum by (cpu) ...`).
  * Returns a flat array of DataPoints keyed by label value, sorted by time.
  */
@@ -249,11 +293,7 @@ export async function fetchFlattenedRange(
 	const dateMap = new Map<number, DataPoint>();
 	for (const vector of vectors) {
 		const key = getLabelKey(vector);
-		for (const sample of vector.values) {
-			const time = (sample.time as Date).getTime();
-			if (!dateMap.has(time)) dateMap.set(time, { date: sample.time as Date });
-			dateMap.get(time)![key] = Number(sample.value);
-		}
+		for (const sample of vector.values) putSample(dateMap, key, sample);
 	}
 	return Array.from(dateMap.values()).sort(
 		(a, b) => (a.date as Date).getTime() - (b.date as Date).getTime()
@@ -280,11 +320,7 @@ export async function fetchMultipleFlattenedRange(
 	const dateMap = new Map<number, DataPoint>();
 	for (const { name, vectors } of results) {
 		for (const vector of vectors) {
-			for (const sample of vector.values) {
-				const time = (sample.time as Date).getTime();
-				if (!dateMap.has(time)) dateMap.set(time, { date: sample.time as Date });
-				dateMap.get(time)![name] = Number(sample.value);
-			}
+			for (const sample of vector.values) putSample(dateMap, name, sample);
 		}
 	}
 	return Array.from(dateMap.values()).sort(
@@ -327,11 +363,7 @@ export async function fetchCombinedFlattenedRange(
 	for (const vector of vectors) {
 		const name = (vector.metric.labels as Record<string, string>)[COMBINED_TAG];
 		if (!name) continue;
-		for (const sample of vector.values) {
-			const time = (sample.time as Date).getTime();
-			if (!dateMap.has(time)) dateMap.set(time, { date: sample.time as Date });
-			dateMap.get(time)![name] = Number(sample.value);
-		}
+		for (const sample of vector.values) putSample(dateMap, name, sample);
 	}
 	return Array.from(dateMap.values()).sort(
 		(a, b) => (a.date as Date).getTime() - (b.date as Date).getTime()


### PR DESCRIPTION
HAMi renamed its scheduler and device-plugin metrics (GPUDeviceMemoryLimit, Device_*_desc_of_container, vGPU_device_memory_*_in_bytes) to a hami_* scheme, and relabelled deviceuuid → device_uuid and podnamespace/podname → exported_namespace/exported_pod. The dashboard still queried the old names, so every GPU query returned an empty vector while Prometheus reported success — the cluster GPU cards and the node table's GPU columns showed "no data" on a cluster with eight healthy RTX 4090s.

Point the queries and label lookups at the new names. GPU Utilization now averages DCGM_FI_DEV_GPU_UTIL instead of HAMi's per-container ratio: the card is titled "average across all GPU cards", DCGM reports per physical card, and the card count beside it already came from DCGM.