### PR TITLE
fix(operator): reset isFetching in all code paths so Reload stays usable

### DIFF
--- a/src/routes/(auth)/[cluster]/[workspace]/operator/+page.svelte
+++ b/src/routes/(auth)/[cluster]/[workspace]/operator/+page.svelte
@@ -148,17 +148,16 @@
 				resource: 'helmrepositories'
 			});
 
-			console.log(response.object);
-
 			if (!response.object) {
 				toast.info('There is no OtterScale Charts Helm Repository.');
 				return;
 			}
 
-			fetchChartsByHelmRepository(response.object as SourceToolkitFluxcdIoV1HelmRepository);
+			await fetchChartsByHelmRepository(response.object as SourceToolkitFluxcdIoV1HelmRepository);
 		} catch (error) {
 			console.error('Failed to list HelmRepositories:', error);
 			toast.error('Failed to list HelmRepository resources');
+		} finally {
 			isFetching = false;
 		}
 	}


### PR DESCRIPTION
isFetching was only cleared on the error branch, so the Reload button permanently disabled itself after the first successful load. Move the reset into a finally block and await the chart fetch so the flag isn't released before loading actually finishes. Also drops a leftover console.log of the raw HelmRepository response.