### PR TITLE
feat: add guide tour and terminal features with localization support

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -772,5 +772,11 @@
 	"license_adjust_nodes_fifo_hint": "FIFO mode: nodes are authorized in the order they joined the cluster.",
 	"license_adjust_nodes_readonly": "This license has expired or is invalid. Node adjustments are not allowed.",
 	"license_adjust_nodes_last_accepted": "Last accepted: ",
-	"containers_without_limit": "{uncapped} of {containers} containers declare no limit"
+	"containers_without_limit": "{uncapped} of {containers} containers declare no limit",
+	"guide_tour": "Guide Tour",
+	"start_guide_tour": "Start Guide Tour",
+	"terminal": "Terminal",
+	"close_terminal": "Close Terminal",
+	"toggle_clusters": "Toggle Clusters",
+	"switch_cluster_action": "Switch Cluster"
 }

--- a/messages/zh-hant.json
+++ b/messages/zh-hant.json
@@ -772,5 +772,11 @@
 	"license_adjust_nodes_fifo_hint": "FIFO 模式：節點依加入叢集的順序自動授權。",
 	"license_adjust_nodes_readonly": "此授權已過期或無效，無法調整節點設定。",
 	"license_adjust_nodes_last_accepted": "上次接受：",
-	"containers_without_limit": "{containers} 個容器中有 {uncapped} 個未宣告 Limit"
+	"containers_without_limit": "{containers} 個容器中有 {uncapped} 個未宣告 Limit",
+	"guide_tour": "導覽教學",
+	"start_guide_tour": "開始導覽教學",
+	"terminal": "終端機",
+	"close_terminal": "關閉終端機",
+	"toggle_clusters": "切換叢集",
+	"switch_cluster_action": "切換叢集"
 }

--- a/src/routes/(auth)/+layout.svelte
+++ b/src/routes/(auth)/+layout.svelte
@@ -2,6 +2,7 @@
 	import 'driver.js/dist/driver.css';
 
 	import { createClient, type Transport } from '@connectrpc/connect';
+	import TerminalIcon from '@lucide/svelte/icons/terminal';
 	import BotIcon from '@lucide/svelte/icons/bot';
 	import BoxIcon from '@lucide/svelte/icons/box';
 	import BracesIcon from '@lucide/svelte/icons/braces';
@@ -17,6 +18,7 @@
 	import LayoutGridIcon from '@lucide/svelte/icons/layout-grid';
 	import NetworkIcon from '@lucide/svelte/icons/network';
 	import UserStarIcon from '@lucide/svelte/icons/user-star';
+	import XIcon from '@lucide/svelte/icons/x';
 	import { type Link, LinkService } from '@otterscale/api/link/v1';
 	import { ResourceService } from '@otterscale/api/resource/v1';
 	import type { TenantOtterscaleIoV1Alpha1Workspace } from '@otterscale/types';
@@ -34,11 +36,13 @@
 		startTour,
 		WorkspaceSwitcher
 	} from '$lib/components/layout';
-	import ImportCluster from '$lib/components/layout/import-cluster-external.svelte';
+	import Registe from '$lib/components/layout/dialog-import-cluster.svelte';
 	import RegisteClusterTrigger from '$lib/components/layout/registe-cluster-trigger.svelte';
+	import { Terminal } from '$lib/components/applications/terminal';
 	import * as Breadcrumb from '$lib/components/ui/breadcrumb';
 	import { Button } from '$lib/components/ui/button';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
+	import * as Resizable from '$lib/components/ui/resizable';
 	import { Separator } from '$lib/components/ui/separator';
 	import * as Sidebar from '$lib/components/ui/sidebar';
 	import { Skeleton } from '$lib/components/ui/skeleton';
@@ -47,7 +51,6 @@
 	import { breadcrumbs } from '$lib/stores';
 	import { pulse } from '$lib/stores/pulse.svelte';
 	import { getAdditionalItems } from '$lib/utils/features';
-	import { hasRookCephCRD } from '$lib/utils/rook-ceph';
 
 	import type { LayoutData } from './$types';
 
@@ -71,7 +74,7 @@
 
 	let sidebarOpen = $state(true);
 	let importOpen = $state(false);
-	let hasRookCeph = $state(false);
+	let terminalOpen = $state(false);
 
 	async function fetchClusters(signal?: AbortSignal): Promise<Link[]> {
 		try {
@@ -164,24 +167,6 @@
 		return () => abortController.abort();
 	});
 
-	$effect(() => {
-		if (!activeCluster) {
-			hasRookCeph = false;
-			return;
-		}
-
-		const abortController = new AbortController();
-		hasRookCephCRD(transport, activeCluster, abortController.signal)
-			.then((exists) => {
-				if (!abortController.signal.aborted) hasRookCeph = exists;
-			})
-			.catch((err) => {
-				if (!abortController.signal.aborted) console.error(err);
-			});
-
-		return () => abortController.abort();
-	});
-
 	function resourceUrl(options: {
 		group: string;
 		version: string;
@@ -246,19 +231,15 @@
 								})
 							: ''
 					},
-					...(hasRookCeph
-						? [
-								{
-									title: m.storage(),
-									url: page.params.workspace
-										? resolve('/(auth)/[cluster]/[workspace]/dashboard/storage', {
-												cluster: activeCluster,
-												workspace: page.params.workspace
-											})
-										: ''
-								}
-							]
-						: [])
+					{
+						title: m.storage(),
+						url: page.params.workspace
+							? resolve('/(auth)/[cluster]/[workspace]/dashboard/storage', {
+									cluster: activeCluster,
+									workspace: page.params.workspace
+								})
+							: ''
+					}
 				]
 			},
 			{
@@ -408,6 +389,21 @@
 							version: 'v1beta1',
 							kind: 'DataVolume',
 							resource: 'datavolumes'
+						})
+					}
+				]
+			},
+			{
+				title: m.storage(),
+				icon: HardDriveIcon,
+				items: [
+					{
+						title: m.object_storage(),
+						url: resourceUrl({
+							group: 'objectbucket.io',
+							version: 'v1alpha1',
+							kind: 'ObjectBucketClaim',
+							resource: 'objectbucketclaims'
 						})
 					}
 				]
@@ -811,11 +807,28 @@
 						{#snippet child({ props })}
 							<Button {...props} variant="ghost" size="icon" class="size-7" onclick={startTour}>
 								<CircleQuestionMarkIcon />
-								<span class="sr-only">Guide Tour</span>
+								<span class="sr-only">{m.guide_tour()}</span>
 							</Button>
 						{/snippet}
 					</Tooltip.Trigger>
-					<Tooltip.Content>Start Guide Tour</Tooltip.Content>
+					<Tooltip.Content>{m.start_guide_tour()}</Tooltip.Content>
+				</Tooltip.Root>
+				<Tooltip.Root>
+					<Tooltip.Trigger>
+						{#snippet child({ props })}
+							<Button
+								{...props}
+								variant="ghost"
+								size="icon"
+								class="size-7"
+								onclick={() => (terminalOpen = !terminalOpen)}
+							>
+								<TerminalIcon />
+								<span class="sr-only">{m.terminal()}</span>
+							</Button>
+						{/snippet}
+					</Tooltip.Trigger>
+					<Tooltip.Content>{m.terminal()}</Tooltip.Content>
 				</Tooltip.Root>
 				<Tooltip.Root>
 					<DropdownMenu.Root>
@@ -830,7 +843,7 @@
 										class="size-7"
 									>
 										<LayersIcon />
-										<span class="sr-only">Toggle Clusters</span>
+										<span class="sr-only">{m.toggle_clusters()}</span>
 									</Button>
 									{#if !activeCluster}
 										<span class="absolute top-3.5 right-3.5 flex size-2.5 transition-all">
@@ -865,13 +878,46 @@
 							</DropdownMenu.Group>
 						</DropdownMenu.Content>
 					</DropdownMenu.Root>
-					<Tooltip.Content>Switch Cluster</Tooltip.Content>
+					<Tooltip.Content>{m.switch_cluster_action()}</Tooltip.Content>
 				</Tooltip.Root>
 			</div>
 		</header>
-		<main class="flex min-w-0 flex-1 flex-col overflow-auto px-2 md:px-4 lg:px-8">
-			{@render children()}
-		</main>
+		<Resizable.PaneGroup direction="vertical" class="min-h-0 flex-1">
+			<Resizable.Pane>
+				<main class="flex h-full min-w-0 flex-col overflow-auto px-2 md:px-4 lg:px-8">
+					{@render children()}
+				</main>
+			</Resizable.Pane>
+			{#if terminalOpen}
+				<Resizable.Handle withHandle />
+				<Resizable.Pane defaultSize={30} minSize={15} class="flex flex-col">
+					<div class="flex shrink-0 items-center justify-between border-b px-4 py-1.5">
+						<span class="flex items-center gap-2 text-sm font-medium">
+							<TerminalIcon class="size-4" />
+							{m.terminal()}
+						</span>
+						<Button
+							variant="ghost"
+							size="icon"
+							class="size-6"
+							onclick={() => (terminalOpen = false)}
+						>
+							<XIcon />
+							<span class="sr-only">{m.close_terminal()}</span>
+						</Button>
+					</div>
+					<div class="min-h-0 flex-1 overflow-hidden bg-[#1e1e1e] p-3">
+						<Terminal
+							cluster={activeCluster}
+							namespace="cdi"
+							podName="cdi-deployment-d6ff6857c-2wtbd"
+							containerName="cdi-deployment"
+							command={['bash']}
+						/>
+					</div>
+				</Resizable.Pane>
+			{/if}
+		</Resizable.PaneGroup>
 	</Sidebar.Inset>
 </Sidebar.Provider>
 
@@ -915,7 +961,7 @@
 	{/each}
 {/snippet}
 
-<ImportCluster
+<Registe
 	bind:open={importOpen}
 	onsuccess={async () => {
 		links = await fetchClusters();


### PR DESCRIPTION
This pull request introduces a new integrated terminal feature into the authenticated layout and improves internationalization for several UI actions. It also simplifies the sidebar navigation logic by removing conditional checks for Rook Ceph and makes the storage navigation always visible. Below are the most important changes:

**Terminal Integration:**
* Added a terminal button to the header that toggles a resizable terminal pane at the bottom of the main layout. The terminal uses the new `Terminal` component and allows users to interact with a cluster pod directly from the UI. [[1]](diffhunk://#diff-aa2ed21fcdb96e31a66fabb392f2bf8723987ce4970b70169549e3c48d2a3143L37-R45) [[2]](diffhunk://#diff-aa2ed21fcdb96e31a66fabb392f2bf8723987ce4970b70169549e3c48d2a3143L74-R77) [[3]](diffhunk://#diff-aa2ed21fcdb96e31a66fabb392f2bf8723987ce4970b70169549e3c48d2a3143L868-R920)

**Internationalization Improvements:**
* Added new translation strings for "Guide Tour," "Terminal," "Close Terminal," "Toggle Clusters," and "Switch Cluster" in both English and Traditional Chinese. Updated relevant UI elements to use these translations for better localization. [[1]](diffhunk://#diff-5d9e5048516ec2fe83ca06813e79c3b8b44c6c96294f25c7311db311e28eeaeeL775-R781) [[2]](diffhunk://#diff-86b81a83a69e55d5eb167ffc2b66fce1e969dc9235cb8e16f105309b08223e34L775-R781) [[3]](diffhunk://#diff-aa2ed21fcdb96e31a66fabb392f2bf8723987ce4970b70169549e3c48d2a3143L814-R831) [[4]](diffhunk://#diff-aa2ed21fcdb96e31a66fabb392f2bf8723987ce4970b70169549e3c48d2a3143L833-R846) [[5]](diffhunk://#diff-aa2ed21fcdb96e31a66fabb392f2bf8723987ce4970b70169549e3c48d2a3143L868-R920)

**Sidebar Navigation Simplification:**
* Removed the conditional logic that checked for the presence of Rook Ceph CRDs before displaying the storage navigation. The storage section is now always shown in the sidebar, streamlining the navigation structure. [[1]](diffhunk://#diff-aa2ed21fcdb96e31a66fabb392f2bf8723987ce4970b70169549e3c48d2a3143L167-L184) [[2]](diffhunk://#diff-aa2ed21fcdb96e31a66fabb392f2bf8723987ce4970b70169549e3c48d2a3143L249-L250) [[3]](diffhunk://#diff-aa2ed21fcdb96e31a66fabb392f2bf8723987ce4970b70169549e3c48d2a3143L261-L262) [[4]](diffhunk://#diff-aa2ed21fcdb96e31a66fabb392f2bf8723987ce4970b70169549e3c48d2a3143R396-R410)

**Component Naming and Import Updates:**
* Renamed the cluster import dialog component from `ImportCluster` to `Registe` and updated its usage accordingly. [[1]](diffhunk://#diff-aa2ed21fcdb96e31a66fabb392f2bf8723987ce4970b70169549e3c48d2a3143L37-R45) [[2]](diffhunk://#diff-aa2ed21fcdb96e31a66fabb392f2bf8723987ce4970b70169549e3c48d2a3143L918-R964)

**UI Icon Imports:**
* Added imports for new icons (`TerminalIcon`, `XIcon`) used in the terminal and header controls. [[1]](diffhunk://#diff-aa2ed21fcdb96e31a66fabb392f2bf8723987ce4970b70169549e3c48d2a3143R5) [[2]](diffhunk://#diff-aa2ed21fcdb96e31a66fabb392f2bf8723987ce4970b70169549e3c48d2a3143R21)