### PR TITLE
feat(dashboard): show measured GPU utilization in the allocation diagram

### DIFF
--- a/src/lib/components/gpu-allocation/fetch-utilization.ts
+++ b/src/lib/components/gpu-allocation/fetch-utilization.ts
@@ -1,0 +1,83 @@
+import type { PrometheusDriver } from 'prometheus-query';
+
+import type { GpuUtilization } from './types';
+
+/**
+ * Measured per-card usage from the DCGM exporter, joined to HAMi's device ids.
+ *
+ * HAMi only ever reports what the *scheduler* booked — `hami.io/node-nvidia-register`
+ * capacity and `hami.io/vgpu-devices-allocated` reservations. Neither says whether a
+ * card is doing any work. DCGM measures the hardware, and its `UUID` label is the same
+ * GPU UUID HAMi uses as a device id, so the two line up per card without a join key of
+ * our own.
+ *
+ * Nothing here is attributable to a pod: DCGM's `pod`/`namespace` labels belong to the
+ * exporter, not the workload on the card (see `classifyGpuGovernance` in $lib/prometheus).
+ */
+
+/** GPU UUIDs are `GPU-<uuid>`; refuse anything else rather than build a regex from it. */
+const SAFE_UUID = /^[A-Za-z0-9_.:-]+$/;
+
+/** One instant query, reduced to value-by-UUID. A failure yields an empty map, never throws. */
+async function instantByUuid(
+	client: PrometheusDriver,
+	query: string
+): Promise<Map<string, number>> {
+	const values = new Map<string, number>();
+	try {
+		const response = await client.instantQuery(query);
+		for (const series of response.result) {
+			const uuid = (series.metric.labels as Record<string, string>).UUID;
+			const value = Number(series.value?.value);
+			if (uuid && Number.isFinite(value)) values.set(uuid, value);
+		}
+	} catch {
+		console.warn('Failed to query GPU utilization:', query);
+	}
+	return values;
+}
+
+/**
+ * Fetch compute and memory usage for the given GPU device ids.
+ *
+ * Returns an entry only for cards DCGM actually reported, so callers can tell "idle"
+ * from "not measured" and render the plain allocation view for the latter.
+ */
+export async function fetchGpuUtilization(
+	client: PrometheusDriver,
+	deviceIds: string[]
+): Promise<Map<string, GpuUtilization>> {
+	const uuids = [...new Set(deviceIds)].filter((id) => SAFE_UUID.test(id));
+	const result = new Map<string, GpuUtilization>();
+	if (uuids.length === 0) return result;
+
+	const selector = `UUID=~"${uuids.join('|')}"`;
+
+	// `max` for the percentage, `sum` for the byte counts: a MIG-partitioned card emits one
+	// series per instance, whose memory adds up but whose utilization does not. Non-MIG cards
+	// emit exactly one series either way. DCGM reports frame buffer in MiB — the unit the rest
+	// of this module already speaks — so no conversion is needed.
+	const [compute, usedMem, totalMem] = await Promise.all([
+		instantByUuid(client, `max by (UUID) (DCGM_FI_DEV_GPU_UTIL{${selector}})`),
+		instantByUuid(client, `sum by (UUID) (DCGM_FI_DEV_FB_USED{${selector}})`),
+		instantByUuid(
+			client,
+			// FB_RESERVED is the driver's own allocation; it belongs in the card's total but not
+			// in what workloads use. Older exporters omit it, and one missing operand would empty
+			// the whole sum — hence the two-term fallback.
+			`sum by (UUID) (DCGM_FI_DEV_FB_USED{${selector}} + DCGM_FI_DEV_FB_FREE{${selector}}` +
+				` + DCGM_FI_DEV_FB_RESERVED{${selector}})` +
+				` or sum by (UUID) (DCGM_FI_DEV_FB_USED{${selector}} + DCGM_FI_DEV_FB_FREE{${selector}})`
+		)
+	]);
+
+	for (const uuid of uuids) {
+		const utilization: GpuUtilization = {
+			compute: compute.get(uuid),
+			usedMem: usedMem.get(uuid),
+			totalMem: totalMem.get(uuid)
+		};
+		if (Object.values(utilization).some((v) => v !== undefined)) result.set(uuid, utilization);
+	}
+	return result;
+}

--- a/src/lib/components/gpu-allocation/gpu-allocation-diagram.svelte
+++ b/src/lib/components/gpu-allocation/gpu-allocation-diagram.svelte
@@ -38,16 +38,36 @@
 		k8sNode: K8sNodeNode as any // eslint-disable-line @typescript-eslint/no-explicit-any
 	};
 
-	// Aggregate GPU memory usage per k8s node (used for the node cards).
+	// Aggregate GPU usage per k8s node (used for the node cards): the memory HAMi booked,
+	// plus what DCGM measures on the same cards. `measuredCards` counts only the cards that
+	// reported, so a node with one unmeasured card still averages honestly over the rest.
 	const gpuUsageByNode = $derived.by(() => {
-		const map = new SvelteMap<string, { usedMem: number }>();
+		const map = new SvelteMap<
+			string,
+			{ usedMem: number; computeSum: number; measuredCards: number }
+		>();
 		for (const gpu of topologyData.gpus) {
-			const agg = map.get(gpu.nodeName) ?? { usedMem: 0 };
+			const agg = map.get(gpu.nodeName) ?? { usedMem: 0, computeSum: 0, measuredCards: 0 };
 			agg.usedMem += gpu.allocatedBy.reduce((sum, a) => sum + a.usedMem, 0);
+			const compute = gpu.utilization?.compute;
+			if (compute !== undefined) {
+				agg.computeSum += compute;
+				agg.measuredCards += 1;
+			}
 			map.set(gpu.nodeName, agg);
 		}
 		return map;
 	});
+
+	/** Whether any card reported measurements — gates the legend entries for them. */
+	const hasUtilization = $derived(topologyData.gpus.some((gpu) => gpu.utilization !== undefined));
+
+	/** Mean measured compute utilization of a node's cards, or undefined if none reported. */
+	function nodeCompute(nodeName: string): number | undefined {
+		const agg = gpuUsageByNode.get(nodeName);
+		if (!agg || agg.measuredCards === 0) return undefined;
+		return agg.computeSum / agg.measuredCards;
+	}
 
 	// GPU device IDs running in MIG mode. Reported per-device by HAMi via the
 	// `mode` field in node-nvidia-register, so idle MIG GPUs (no pods yet) are
@@ -145,7 +165,8 @@
 						usedMem: totalUsedMem,
 						shareCount: gpu.allocatedBy.length,
 						isMig: migGpuIds.has(gpu.device.id),
-						slices: isGpuMigMode(gpu.device) ? buildMigSlices(gpu.allocatedBy) : []
+						slices: isGpuMigMode(gpu.device) ? buildMigSlices(gpu.allocatedBy) : [],
+						utilization: gpu.utilization
 					}
 				});
 			}
@@ -165,6 +186,7 @@
 						gpuType,
 						totalMem: node.devices.reduce((sum, d) => sum + d.devmem, 0),
 						usedMem: gpuUsageByNode.get(node.name)?.usedMem ?? 0,
+						compute: nodeCompute(node.name),
 						healthyCount: node.devices.filter((d) => d.health).length,
 						isMig: node.devices.some((d) => migGpuIds.has(d.id))
 					}
@@ -236,7 +258,8 @@
 						usedMem: totalUsedMem,
 						shareCount: gpu.allocatedBy.length,
 						isMig: migGpuIds.has(gpu.device.id),
-						slices: isGpuMigMode(gpu.device) ? buildMigSlices(gpu.allocatedBy) : []
+						slices: isGpuMigMode(gpu.device) ? buildMigSlices(gpu.allocatedBy) : [],
+						utilization: gpu.utilization
 					}
 				});
 			}
@@ -256,6 +279,7 @@
 						gpuType,
 						totalMem: node.devices.reduce((sum, d) => sum + d.devmem, 0),
 						usedMem: gpuUsageByNode.get(node.name)?.usedMem ?? 0,
+						compute: nodeCompute(node.name),
 						healthyCount: node.devices.filter((d) => d.health).length,
 						isMig: node.devices.some((d) => migGpuIds.has(d.id))
 					}
@@ -363,6 +387,24 @@
 						>
 						<span>KV cache offload to SSD</span>
 					</div>
+					<div class="flex items-center gap-2">
+						<span class="size-2.5 rounded-sm border border-destructive bg-card"></span>
+						<span>Red border: unhealthy or failing</span>
+					</div>
+					{#if hasUtilization}
+						<div class="flex items-center gap-2">
+							<span class="rounded-full bg-chart-2/10 px-1 text-[9px] font-medium text-chart-2"
+								>42%</span
+							>
+							<span>Compute utilization (measured)</span>
+						</div>
+						<div class="flex items-center gap-2">
+							<span class="relative block h-1.5 w-4 overflow-hidden rounded-full bg-chart-4/30">
+								<span class="absolute inset-y-0 left-0 w-1.5 rounded-full bg-chart-4"></span>
+							</span>
+							<span>Memory in use / allocated</span>
+						</div>
+					{/if}
 					<div class="mt-1 flex items-center gap-2 border-t border-border pt-1.5">
 						<span class="h-0.5 w-4 rounded-full bg-primary"></span>
 						<span>Active allocation</span>

--- a/src/lib/components/gpu-allocation/gpu-allocation-dialog.svelte
+++ b/src/lib/components/gpu-allocation/gpu-allocation-dialog.svelte
@@ -2,6 +2,7 @@
 	import { ConnectError, createClient, type Transport } from '@connectrpc/connect';
 	import GpuIcon from '@lucide/svelte/icons/gpu';
 	import { ResourceService } from '@otterscale/api/resource/v1';
+	import { PrometheusDriver } from 'prometheus-query';
 	import { getContext, type Snippet } from 'svelte';
 
 	import * as Dialog from '$lib/components/ui/dialog';
@@ -9,6 +10,7 @@
 	import { m } from '$lib/messages';
 
 	import { fetchLLMInferenceServiceTopology, fetchNodeTopology } from './fetch-topology';
+	import { fetchGpuUtilization } from './fetch-utilization';
 	import GpuAllocationDiagram from './gpu-allocation-diagram.svelte';
 	import type { TopologyData, TopologyView } from './types';
 
@@ -40,17 +42,52 @@
 	let error = $state<string | null>(null);
 	let topologyData = $state<TopologyData | null>(null);
 
+	/** Bumped per open so a slow metrics response can't land on a later topology. */
+	let requestId = 0;
+
+	/**
+	 * Attach measured per-card usage to the topology already on screen. Runs after the
+	 * diagram renders rather than as part of `fetchData`, so an unreachable Prometheus
+	 * only costs the utilization bars — never the allocation view itself.
+	 */
+	async function attachUtilization(data: TopologyData, id: number) {
+		if (data.gpus.length === 0) return;
+
+		try {
+			const prometheus = new PrometheusDriver({
+				endpoint: `/proxy/${cluster}/prometheus`,
+				baseURL: '/api/v1',
+				headers: { 'x-proxy-target': 'api' }
+			});
+			const utilization = await fetchGpuUtilization(
+				prometheus,
+				data.gpus.map((gpu) => gpu.device.id)
+			);
+			if (id !== requestId || utilization.size === 0) return;
+
+			topologyData = {
+				...data,
+				gpus: data.gpus.map((gpu) => ({ ...gpu, utilization: utilization.get(gpu.device.id) }))
+			};
+		} catch (err) {
+			console.warn('Failed to fetch GPU utilization:', err);
+		}
+	}
+
 	async function fetchData() {
+		const id = ++requestId;
 		isLoading = true;
 		error = null;
 		topologyData = null;
 
 		try {
-			if (view === 'llm-inference-service') {
-				topologyData = await fetchLLMInferenceServiceTopology(client, cluster, namespace, name);
-			} else {
-				topologyData = await fetchNodeTopology(client, cluster, object);
-			}
+			const data =
+				view === 'llm-inference-service'
+					? await fetchLLMInferenceServiceTopology(client, cluster, namespace, name)
+					: await fetchNodeTopology(client, cluster, object);
+			if (id !== requestId) return;
+			topologyData = data;
+			void attachUtilization(data, id);
 		} catch (err) {
 			console.error('Failed to fetch GPU allocation:', err);
 			error = m.gpu_allocation_fetch_error({ message: (err as ConnectError).message });

--- a/src/lib/components/gpu-allocation/nodes/gpu-node.svelte
+++ b/src/lib/components/gpu-allocation/nodes/gpu-node.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
+	import Activity from '@lucide/svelte/icons/activity';
 	import Gpu from '@lucide/svelte/icons/gpu';
 	import Users from '@lucide/svelte/icons/users';
 	import type { Node, NodeProps } from '@xyflow/svelte';
 	import { Handle, Position } from '@xyflow/svelte';
 
 	import { formatMemory, toPercent } from '../format';
-	import type { MigSlice } from '../types';
+	import type { GpuUtilization, MigSlice } from '../types';
 
 	type GpuNodeData = {
 		index: number;
@@ -16,6 +17,7 @@
 		shareCount: number;
 		isMig: boolean;
 		slices: MigSlice[];
+		utilization?: GpuUtilization;
 		hasTargetEdge: boolean;
 		hasSourceEdge: boolean;
 	};
@@ -24,6 +26,42 @@
 
 	const usedMemPct = $derived(toPercent(data.usedMem, data.totalMem));
 	const slices = $derived(data.slices ?? []);
+
+	// Health is carried by the card's border rather than a status dot: a healthy diagram then
+	// has no decoration at all, and an unhealthy card is marked without tinting its contents.
+	// The red border also holds through hover, which the shared primary hover would eat.
+	const cardStateClass = $derived(
+		data.health ? 'border-border hover:border-primary/50' : 'border-destructive'
+	);
+
+	// Measured usage (DCGM), as opposed to what the HAMi scheduler booked. Absent whenever
+	// the exporter reports nothing for this card, in which case the card falls back to the
+	// booking-only view it had before.
+	const computePct = $derived.by(() => {
+		const compute = data.utilization?.compute;
+		return compute === undefined ? undefined : Math.min(100, Math.max(0, Math.round(compute)));
+	});
+	const measuredMem = $derived(data.utilization?.usedMem);
+	// Plotted against HAMi's `devmem` so both layers of the bar share one denominator; the
+	// card's physical size goes in the tooltip, where the two can differ (deviceMemoryScaling).
+	const measuredMemPct = $derived(
+		measuredMem === undefined ? undefined : toPercent(measuredMem, data.totalMem)
+	);
+	// The row reads out the measurement once there is one, and the booking otherwise.
+	const memoryText = $derived(
+		measuredMem !== undefined
+			? `${formatMemory(measuredMem)} / ${formatMemory(data.totalMem)} (${measuredMemPct}%)`
+			: `${formatMemory(data.usedMem)} / ${formatMemory(data.totalMem)} (${usedMemPct}%)`
+	);
+	// Spells out the booking behind the faded layer of the bar, which the row itself
+	// only shows once a measurement replaces it.
+	const memoryTitle = $derived.by(() => {
+		const parts = [`Allocated ${formatMemory(data.usedMem)} of ${formatMemory(data.totalMem)}`];
+		if (measuredMem !== undefined) parts.push(`In use ${formatMemory(measuredMem)}`);
+		const physical = data.utilization?.totalMem;
+		if (physical !== undefined) parts.push(`Card ${formatMemory(physical)}`);
+		return parts.join(' · ');
+	});
 </script>
 
 {#if data.hasTargetEdge}
@@ -33,37 +71,45 @@
 <div
 	class="flex {data.isMig
 		? 'h-40'
-		: 'h-28'} w-52 flex-col overflow-hidden rounded-lg border border-border bg-card text-card-foreground shadow-sm transition-all duration-200 hover:border-primary/50 hover:shadow-md {selected
+		: 'h-28'} w-52 flex-col overflow-hidden rounded-lg border bg-card text-card-foreground shadow-sm transition-all duration-200 hover:shadow-md {cardStateClass} {selected
 		? 'ring-2 ring-primary ring-offset-2 ring-offset-background'
 		: ''}"
+	title={data.health ? undefined : 'This GPU is reported unhealthy by HAMi'}
 >
 	<div class="flex items-center gap-2 border-b border-border px-3 py-2">
 		<div class="flex size-6 items-center justify-center rounded-md bg-chart-4/10">
 			<Gpu size={14} class="text-chart-4" />
 		</div>
 		<span class="truncate text-sm font-semibold">GPU #{data.index}</span>
-		{#if data.isMig}
-			<span
-				class="ml-auto rounded-sm bg-chart-3/10 px-1.5 py-0.5 text-[10px] font-medium text-chart-3"
-				title="MIG-partitioned GPU"
-			>
-				MIG
-			</span>
-		{:else if data.shareCount > 1}
-			<span
-				class="ml-auto flex items-center gap-0.5 rounded-full bg-chart-4/10 px-1.5 py-0.5 text-[10px] font-medium text-chart-4"
-				title="{data.shareCount} pods sharing this GPU"
-			>
-				<Users size={10} />
-				{data.shareCount}
-			</span>
-		{/if}
-		<span
-			class="inline-block size-2 shrink-0 rounded-full {data.health
-				? 'bg-green-500'
-				: 'bg-red-500'} {data.isMig || data.shareCount > 1 ? '' : 'ml-auto'}"
-			title={data.health ? 'Healthy' : 'Unhealthy'}
-		></span>
+		<div class="ml-auto flex shrink-0 items-center gap-1.5">
+			{#if computePct !== undefined}
+				<!-- Measured utilization rides in the header so it costs the card no height.
+					 Whole-card figure: a shared GPU reports one number for every pod on it. -->
+				<span
+					class="flex items-center gap-0.5 rounded-full bg-chart-2/10 px-1.5 py-0.5 text-[10px] font-medium text-chart-2 tabular-nums"
+					title="Compute (SM) utilization of the whole card, measured by DCGM"
+				>
+					<Activity size={9} />
+					{computePct}%
+				</span>
+			{/if}
+			{#if data.isMig}
+				<span
+					class="rounded-sm bg-chart-3/10 px-1.5 py-0.5 text-[10px] font-medium text-chart-3"
+					title="MIG-partitioned GPU"
+				>
+					MIG
+				</span>
+			{:else if data.shareCount > 1}
+				<span
+					class="flex items-center gap-0.5 rounded-full bg-chart-4/10 px-1.5 py-0.5 text-[10px] font-medium text-chart-4"
+					title="{data.shareCount} pods sharing this GPU"
+				>
+					<Users size={10} />
+					{data.shareCount}
+				</span>
+			{/if}
+		</div>
 	</div>
 	<div class="space-y-2 px-3 py-2">
 		<div class="truncate text-xs font-medium" title={data.type}>{data.type || 'Unknown'}</div>
@@ -92,17 +138,26 @@
 				<div class="text-[11px] text-muted-foreground">MIG enabled · no active instances</div>
 			{/if}
 		{:else}
-			<!-- Memory usage: whole GPU or vGPU share -->
-			<div class="space-y-1">
+			<!-- Memory: the faded layer is what HAMi booked, the solid one what DCGM measures in
+				 use. Without a measurement the booking is drawn solid, as it was before. -->
+			<div class="space-y-1" title={memoryTitle}>
 				<div class="flex items-center justify-between text-[11px] text-muted-foreground">
 					<span>Memory</span>
-					<span>{formatMemory(data.usedMem)} / {formatMemory(data.totalMem)} ({usedMemPct}%)</span>
+					<span>{memoryText}</span>
 				</div>
-				<div class="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+				<div class="relative h-1.5 w-full overflow-hidden rounded-full bg-muted">
 					<div
-						class="h-full rounded-full bg-chart-4 transition-all"
+						class="absolute inset-y-0 left-0 rounded-full transition-all {measuredMem !== undefined
+							? 'bg-chart-4/30'
+							: 'bg-chart-4'}"
 						style="width: {usedMemPct}%"
 					></div>
+					{#if measuredMemPct !== undefined}
+						<div
+							class="absolute inset-y-0 left-0 rounded-full bg-chart-4 transition-all"
+							style="width: {measuredMemPct}%"
+						></div>
+					{/if}
 				</div>
 			</div>
 		{/if}

--- a/src/lib/components/gpu-allocation/nodes/k8s-node-node.svelte
+++ b/src/lib/components/gpu-allocation/nodes/k8s-node-node.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import Activity from '@lucide/svelte/icons/activity';
 	import Server from '@lucide/svelte/icons/server';
 	import type { NodeProps } from '@xyflow/svelte';
 	import { Handle, Position } from '@xyflow/svelte';
@@ -13,6 +14,14 @@
 	const usedMem = $derived(Number(data.usedMem ?? 0));
 	const usedMemPct = $derived(toPercent(usedMem, totalMem));
 	const isMig = $derived(Boolean(data.isMig));
+
+	// Mean measured compute utilization across the node's cards (DCGM); undefined when none
+	// of them reported, so the row disappears rather than claiming an idle node.
+	const computePct = $derived.by(() => {
+		const compute = data.compute;
+		if (typeof compute !== 'number' || !Number.isFinite(compute)) return undefined;
+		return Math.min(100, Math.max(0, Math.round(compute)));
+	});
 </script>
 
 {#if data.hasTargetEdge}
@@ -29,22 +38,32 @@
 			<Server size={14} class="text-muted-foreground" />
 		</div>
 		<span class="truncate text-sm font-semibold">Node</span>
-		{#if isMig}
+		<div class="ml-auto flex shrink-0 items-center gap-1.5">
+			{#if computePct !== undefined}
+				<!-- Mean over the node's cards, in the header so it costs the card no height. -->
+				<span
+					class="flex items-center gap-0.5 rounded-full bg-chart-2/10 px-1.5 py-0.5 text-[10px] font-medium text-chart-2 tabular-nums"
+					title="Mean compute (SM) utilization across this node's GPU cards, measured by DCGM"
+				>
+					<Activity size={9} />
+					{computePct}%
+				</span>
+			{/if}
+			{#if isMig}
+				<span
+					class="rounded-sm bg-chart-3/10 px-1.5 py-0.5 text-[10px] font-medium text-chart-3"
+					title="This node has MIG-partitioned GPUs"
+				>
+					MIG
+				</span>
+			{/if}
 			<span
-				class="ml-auto rounded-sm bg-chart-3/10 px-1.5 py-0.5 text-[10px] font-medium text-chart-3"
-				title="This node has MIG-partitioned GPUs"
+				class="rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground"
+				title="{healthyCount} of {gpuCount} GPUs healthy"
 			>
-				MIG
+				{healthyCount}/{gpuCount} GPU
 			</span>
-		{/if}
-		<span
-			class="{isMig
-				? ''
-				: 'ml-auto'} rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground"
-			title="{healthyCount} of {gpuCount} GPUs healthy"
-		>
-			{healthyCount}/{gpuCount} GPU
-		</span>
+		</div>
 	</div>
 	<div class="space-y-1.5 px-3 py-2">
 		<div class="truncate text-xs font-medium" title={String(data.name ?? '')}>{data.name}</div>

--- a/src/lib/components/gpu-allocation/nodes/pod-node.svelte
+++ b/src/lib/components/gpu-allocation/nodes/pod-node.svelte
@@ -30,14 +30,30 @@
 
 	// Everything else (Pending, ContainerCreating, PodInitializing, Init:*,
 	// Terminating, NotReady) is a transitional state -> amber, never green.
-	function statusColorOf(status: string): string {
-		if (OK_STATUSES.has(status)) return 'bg-green-500';
-		if (status === 'Unknown') return 'bg-muted-foreground';
-		if (ERROR_HINTS.some((hint) => status.includes(hint))) return 'bg-red-500';
-		return 'bg-yellow-500';
+	function statusStateOf(status: string): 'ok' | 'unknown' | 'error' | 'transitional' {
+		if (OK_STATUSES.has(status)) return 'ok';
+		if (status === 'Unknown') return 'unknown';
+		if (ERROR_HINTS.some((hint) => status.includes(hint))) return 'error';
+		return 'transitional';
 	}
 
-	const statusColor = $derived(statusColorOf(String(data.status ?? 'Unknown')));
+	const status = $derived(String(data.status ?? 'Unknown'));
+
+	// Status is carried by the card's border rather than a status dot, so a healthy diagram
+	// has no decoration and a pod in trouble is marked without tinting its contents. The
+	// coloured borders also hold through hover, which the shared primary hover would eat.
+	const cardStateClass = $derived.by(() => {
+		switch (statusStateOf(status)) {
+			case 'ok':
+				return 'border-border hover:border-primary/50';
+			case 'error':
+				return 'border-destructive';
+			case 'transitional':
+				return 'border-amber-500';
+			case 'unknown':
+				return 'border-muted-foreground/50';
+		}
+	});
 
 	const roleLabelMap: Record<string, string> = {
 		decode: 'Decode',
@@ -77,9 +93,10 @@
 {/if}
 
 <div
-	class="w-64 rounded-lg border border-border bg-card text-card-foreground shadow-sm transition-all duration-200 hover:border-primary/50 hover:shadow-md {selected
+	class="w-64 rounded-lg border bg-card text-card-foreground shadow-sm transition-all duration-200 hover:shadow-md {cardStateClass} {selected
 		? 'ring-2 ring-primary ring-offset-2 ring-offset-background'
 		: ''}"
+	title={statusStateOf(status) === 'ok' ? undefined : status}
 >
 	<div class="flex items-center gap-2 border-b border-border px-3 py-2">
 		<div class="flex size-6 items-center justify-center rounded-md bg-chart-2/10">
@@ -114,12 +131,6 @@
 				KV Offload
 			</span>
 		{/if}
-		<span
-			class="inline-block size-2 shrink-0 rounded-full {statusColor} {roleLabel || isMig || usesSsd
-				? ''
-				: 'ml-auto'}"
-			title={String(data.status ?? 'Unknown')}
-		></span>
 	</div>
 	<div class="space-y-1.5 px-3 py-2">
 		<div class="truncate text-xs font-medium" title={String(data.name ?? '')}>{data.name}</div>

--- a/src/lib/components/gpu-allocation/types.ts
+++ b/src/lib/components/gpu-allocation/types.ts
@@ -43,10 +43,27 @@ export interface PodInfo {
 	pvcs: PodPvc[];
 }
 
+/**
+ * Live per-card telemetry from the DCGM exporter, keyed by GPU UUID. Every field is
+ * optional: DCGM is a separate exporter from HAMi, so a card registered by HAMi may
+ * have no measurements at all (no GPU Operator, Prometheus unreachable, metric absent).
+ * Fields are never attributable to a pod — DCGM measures the whole card.
+ */
+export interface GpuUtilization {
+	/** Compute (SM) utilization, 0-100. */
+	compute?: number;
+	/** Frame buffer in use by workloads, MiB. Excludes the driver's reserved buffer. */
+	usedMem?: number;
+	/** Physical frame buffer of the card, MiB — HAMi's `devmem` is the scheduler's pool. */
+	totalMem?: number;
+}
+
 export interface GpuInfo {
 	device: GpuDevice;
 	nodeName: string;
 	allocatedBy: { podName: string; podNamespace: string; usedCores: number; usedMem: number }[];
+	/** Measured usage of the card; absent when DCGM reports nothing for it. */
+	utilization?: GpuUtilization;
 }
 
 export interface NodeInfo {


### PR DESCRIPTION
The dialog only showed what the HAMi scheduler booked, which says nothing about whether a card is doing work — a fully booked idle GPU looked like a saturated one. Join DCGM's per-card series to HAMi's device ids (both key on the GPU UUID) and add a utilization badge to the GPU and node cards, plus a second layer on the memory bar: faded is the booking, solid is measured use.

Metrics are fetched after the topology renders, so an unreachable Prometheus costs only the badges. Health also moves from a status dot to the card border.